### PR TITLE
Implement data storage on OreSat using littlefs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "common/CANopenNode"]
 	path = ext/CANopenNode
 	url = https://github.com/CANopenNode/CANopenNode.git
+[submodule "ext/littlefs"]
+	path = ext/littlefs
+	url = git@github.com:ARMmbed/littlefs.git

--- a/common/include/mmc.h
+++ b/common/include/mmc.h
@@ -9,6 +9,10 @@
 extern "C" {
 #endif
 
+/* LFS objects */
+extern lfs_t lfs;
+extern struct lfs_config lfscfg;
+
 /* eMMC support functions */
 int mmc_enable(void);
 void mmc_disable(void);

--- a/common/lfs_util.c
+++ b/common/lfs_util.c
@@ -1,0 +1,26 @@
+/*
+ * lfs util functions
+ *
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "lfs_util.h"
+
+// Software CRC implementation with small lookup table
+uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
+    static const uint32_t rtable[16] = {
+        0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac,
+        0x76dc4190, 0x6b6b51f4, 0x4db26158, 0x5005713c,
+        0xedb88320, 0xf00f9344, 0xd6d6a3e8, 0xcb61b38c,
+        0x9b64c2b0, 0x86d3d2d4, 0xa00ae278, 0xbdbdf21c,
+    };
+
+    const uint8_t *data = buffer;
+
+    for (size_t i = 0; i < size; i++) {
+        crc = (crc >> 4) ^ rtable[(crc ^ (data[i] >> 0)) & 0xf];
+        crc = (crc >> 4) ^ rtable[(crc ^ (data[i] >> 4)) & 0xf];
+    }
+
+    return crc;
+}

--- a/common/littlefs.mk
+++ b/common/littlefs.mk
@@ -5,7 +5,7 @@ LITTLEFS_SRC = $(PROJ_ROOT)/ext/littlefs
 
 # List of all littlefs sources
 LITTLEFSSRC := $(LITTLEFS_SRC)/lfs.c                    \
-               $(LITTLEFS_SRC)/lfs_util.c
+               $(PROJ_SRC)/lfs_util.c
 
 # Required include directories
 LITTLEFSINC := $(LITTLEFS_SRC)

--- a/common/littlefs.mk
+++ b/common/littlefs.mk
@@ -1,0 +1,15 @@
+# Required libraries for littlefs
+#include $(PROJ_SRC)/include.mk
+
+LITTLEFS_SRC = $(PROJ_ROOT)/ext/littlefs
+
+# List of all littlefs sources
+LITTLEFSSRC := $(LITTLEFS_SRC)/lfs.c                    \
+               $(LITTLEFS_SRC)/lfs_util.c
+
+# Required include directories
+LITTLEFSINC := $(LITTLEFS_SRC)
+
+# Shared variables
+ALLCSRC     += $(LITTLEFSSRC)
+ALLINC      += $(LITTLEFSINC)

--- a/common/littlefs.mk
+++ b/common/littlefs.mk
@@ -5,7 +5,8 @@ LITTLEFS_SRC = $(PROJ_ROOT)/ext/littlefs
 
 # List of all littlefs sources
 LITTLEFSSRC := $(LITTLEFS_SRC)/lfs.c                    \
-               $(PROJ_SRC)/lfs_util.c
+               $(PROJ_SRC)/lfs_util.c                   \
+			   $(PROJ_SRC)/mmc.c
 
 # Required include directories
 LITTLEFSINC := $(LITTLEFS_SRC)

--- a/common/mmc.c
+++ b/common/mmc.c
@@ -41,7 +41,6 @@ struct lfs_config lfscfg = {
 /*===========================================================================*/
 int mmc_enable(void)
 {
-    int err;
     BlockDeviceInfo bdinfo;
 
     /* Enable power to eMMC */
@@ -52,6 +51,8 @@ int mmc_enable(void)
 
     /* Connect to eMMC device */
     if (blkConnect(SDC)) {
+        sdcStop(SDC);
+        palSetLine(LINE_MMC_PWR);
         return LFS_ERR_IO;
     }
 
@@ -67,10 +68,8 @@ int mmc_enable(void)
     _mmcsd_unpack_mmc_cid((MMCSDBlockDevice*)SDC, &mmc_cid);
     _mmcsd_unpack_csd_mmc((MMCSDBlockDevice*)SDC, &mmc_csd);
 
-    /* Mount LFS file system */
-    err = lfs_mount(&lfs, &lfscfg);
-
-    return err;
+    /* Mount LFS file system and return status */
+    return lfs_mount(&lfs, &lfscfg);
 }
 
 void mmc_disable(void)
@@ -78,10 +77,8 @@ void mmc_disable(void)
     /* Unmount LFS file system */
     lfs_unmount(&lfs);
 
-    /* Disconnect from eMMC device */
+    /* Disconnect from eMMC device and stop interface */
     blkDisconnect(SDC);
-
-    /* Stop MMC SDC interface */
     sdcStop(SDC);
 
     /* Disable power to eMMC */

--- a/src/f4/app_control/Makefile
+++ b/src/f4/app_control/Makefile
@@ -110,6 +110,7 @@ include $(PROJ_SRC)/oresat.mk
 include $(PROJ_SRC)/opd.mk
 include $(PROJ_SRC)/time_sync.mk
 include $(PROJ_SRC)/CO_master.mk
+include $(PROJ_SRC)/littlefs.mk
 
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/src/f4/app_control/Makefile
+++ b/src/f4/app_control/Makefile
@@ -171,7 +171,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = -DSHELL_CONFIG_FILE -DMAX7310_SHARED_I2C
+UDEFS = -DSHELL_CONFIG_FILE -DMAX7310_SHARED_I2C -DLFS_CONFIG=lfsconf.h
 
 # Define ASM defines here
 UADEFS =

--- a/src/f4/app_control/cfg/lfsconf.h
+++ b/src/f4/app_control/cfg/lfsconf.h
@@ -38,7 +38,7 @@ extern "C"
 // Logging functions
 #ifdef LFS_YES_TRACE
 #define LFS_TRACE_(fmt, ...) \
-    chprintf((BaseSequentialStream*)&SD3, "%s:%d:trace: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:trace: " fmt "%s\r\n", __FILE__, __LINE__, __VA_ARGS__)
 #define LFS_TRACE(...) LFS_TRACE_(__VA_ARGS__, "")
 #else
 #define LFS_TRACE(...)
@@ -46,7 +46,7 @@ extern "C"
 
 #ifndef LFS_NO_DEBUG
 #define LFS_DEBUG_(fmt, ...) \
-    chprintf((BaseSequentialStream*)&SD3, "%s:%d:debug: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:debug: " fmt "%s\r\n", __FILE__, __LINE__, __VA_ARGS__)
 #define LFS_DEBUG(...) LFS_DEBUG_(__VA_ARGS__, "")
 #else
 #define LFS_DEBUG(...)
@@ -54,7 +54,7 @@ extern "C"
 
 #ifndef LFS_NO_WARN
 #define LFS_WARN_(fmt, ...) \
-    chprintf((BaseSequentialStream*)&SD3, "%s:%d:warn: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:warn: " fmt "%s\r\n", __FILE__, __LINE__, __VA_ARGS__)
 #define LFS_WARN(...) LFS_WARN_(__VA_ARGS__, "")
 #else
 #define LFS_WARN(...)
@@ -62,7 +62,7 @@ extern "C"
 
 #ifndef LFS_NO_ERROR
 #define LFS_ERROR_(fmt, ...) \
-    chprintf((BaseSequentialStream*)&SD3, "%s:%d:error: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:error: " fmt "%s\r\n", __FILE__, __LINE__, __VA_ARGS__)
 #define LFS_ERROR(...) LFS_ERROR_(__VA_ARGS__, "")
 #else
 #define LFS_ERROR(...)

--- a/src/f4/app_control/cfg/lfsconf.h
+++ b/src/f4/app_control/cfg/lfsconf.h
@@ -1,0 +1,220 @@
+/*
+ * lfs utility functions
+ *
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef LFS_CONF_H
+#define LFS_CONF_H
+
+// System includes
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <inttypes.h>
+#include "ch.h"
+#include "hal.h"
+
+#ifndef LFS_NO_MALLOC
+#include <stdlib.h>
+#endif
+#if !defined(LFS_NO_DEBUG) || \
+        !defined(LFS_NO_WARN) || \
+        !defined(LFS_NO_ERROR) || \
+        defined(LFS_YES_TRACE)
+#include "chprintf.h"
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+// Macros, may be replaced by system specific wrappers. Arguments to these
+// macros must not have side-effects as the macros can be removed for a smaller
+// code footprint
+
+// Logging functions
+#ifdef LFS_YES_TRACE
+#define LFS_TRACE_(fmt, ...) \
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:trace: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+#define LFS_TRACE(...) LFS_TRACE_(__VA_ARGS__, "")
+#else
+#define LFS_TRACE(...)
+#endif
+
+#ifndef LFS_NO_DEBUG
+#define LFS_DEBUG_(fmt, ...) \
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:debug: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+#define LFS_DEBUG(...) LFS_DEBUG_(__VA_ARGS__, "")
+#else
+#define LFS_DEBUG(...)
+#endif
+
+#ifndef LFS_NO_WARN
+#define LFS_WARN_(fmt, ...) \
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:warn: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+#define LFS_WARN(...) LFS_WARN_(__VA_ARGS__, "")
+#else
+#define LFS_WARN(...)
+#endif
+
+#ifndef LFS_NO_ERROR
+#define LFS_ERROR_(fmt, ...) \
+    chprintf((BaseSequentialStream*)&SD3, "%s:%d:error: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+#define LFS_ERROR(...) LFS_ERROR_(__VA_ARGS__, "")
+#else
+#define LFS_ERROR(...)
+#endif
+
+// Runtime assertions
+#ifndef LFS_NO_ASSERT
+#define LFS_ASSERT(test) chDbgCheck(test)
+#else
+#define LFS_ASSERT(test)
+#endif
+
+
+// Builtin functions, these may be replaced by more efficient
+// toolchain-specific implementations. LFS_NO_INTRINSICS falls back to a more
+// expensive basic C implementation for debugging purposes
+
+// Min/max functions for unsigned 32-bit numbers
+static inline uint32_t lfs_max(uint32_t a, uint32_t b) {
+    return (a > b) ? a : b;
+}
+
+static inline uint32_t lfs_min(uint32_t a, uint32_t b) {
+    return (a < b) ? a : b;
+}
+
+// Align to nearest multiple of a size
+static inline uint32_t lfs_aligndown(uint32_t a, uint32_t alignment) {
+    return a - (a % alignment);
+}
+
+static inline uint32_t lfs_alignup(uint32_t a, uint32_t alignment) {
+    return lfs_aligndown(a + alignment-1, alignment);
+}
+
+// Find the smallest power of 2 greater than or equal to a
+static inline uint32_t lfs_npw2(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && (defined(__GNUC__) || defined(__CC_ARM))
+    return 32 - __builtin_clz(a-1);
+#else
+    uint32_t r = 0;
+    uint32_t s;
+    a -= 1;
+    s = (a > 0xffff) << 4; a >>= s; r |= s;
+    s = (a > 0xff  ) << 3; a >>= s; r |= s;
+    s = (a > 0xf   ) << 2; a >>= s; r |= s;
+    s = (a > 0x3   ) << 1; a >>= s; r |= s;
+    return (r | (a >> 1)) + 1;
+#endif
+}
+
+// Count the number of trailing binary zeros in a
+// lfs_ctz(0) may be undefined
+static inline uint32_t lfs_ctz(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && defined(__GNUC__)
+    return __builtin_ctz(a);
+#else
+    return lfs_npw2((a & -a) + 1) - 1;
+#endif
+}
+
+// Count the number of binary ones in a
+static inline uint32_t lfs_popc(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && (defined(__GNUC__) || defined(__CC_ARM))
+    return __builtin_popcount(a);
+#else
+    a = a - ((a >> 1) & 0x55555555);
+    a = (a & 0x33333333) + ((a >> 2) & 0x33333333);
+    return (((a + (a >> 4)) & 0xf0f0f0f) * 0x1010101) >> 24;
+#endif
+}
+
+// Find the sequence comparison of a and b, this is the distance
+// between a and b ignoring overflow
+static inline int lfs_scmp(uint32_t a, uint32_t b) {
+    return (int)(unsigned)(a - b);
+}
+
+// Convert between 32-bit little-endian and native order
+static inline uint32_t lfs_fromle32(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && ( \
+    (defined(  BYTE_ORDER  ) && defined(  ORDER_LITTLE_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_LITTLE_ENDIAN  ) || \
+    (defined(__BYTE_ORDER  ) && defined(__ORDER_LITTLE_ENDIAN  ) && __BYTE_ORDER   == __ORDER_LITTLE_ENDIAN  ) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+    return a;
+#elif !defined(LFS_NO_INTRINSICS) && ( \
+    (defined(  BYTE_ORDER  ) && defined(  ORDER_BIG_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_BIG_ENDIAN  ) || \
+    (defined(__BYTE_ORDER  ) && defined(__ORDER_BIG_ENDIAN  ) && __BYTE_ORDER   == __ORDER_BIG_ENDIAN  ) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+    return __builtin_bswap32(a);
+#else
+    return (((uint8_t*)&a)[0] <<  0) |
+           (((uint8_t*)&a)[1] <<  8) |
+           (((uint8_t*)&a)[2] << 16) |
+           (((uint8_t*)&a)[3] << 24);
+#endif
+}
+
+static inline uint32_t lfs_tole32(uint32_t a) {
+    return lfs_fromle32(a);
+}
+
+// Convert between 32-bit big-endian and native order
+static inline uint32_t lfs_frombe32(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && ( \
+    (defined(  BYTE_ORDER  ) && defined(  ORDER_LITTLE_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_LITTLE_ENDIAN  ) || \
+    (defined(__BYTE_ORDER  ) && defined(__ORDER_LITTLE_ENDIAN  ) && __BYTE_ORDER   == __ORDER_LITTLE_ENDIAN  ) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+    return __builtin_bswap32(a);
+#elif !defined(LFS_NO_INTRINSICS) && ( \
+    (defined(  BYTE_ORDER  ) && defined(  ORDER_BIG_ENDIAN  ) &&   BYTE_ORDER   ==   ORDER_BIG_ENDIAN  ) || \
+    (defined(__BYTE_ORDER  ) && defined(__ORDER_BIG_ENDIAN  ) && __BYTE_ORDER   == __ORDER_BIG_ENDIAN  ) || \
+    (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+    return a;
+#else
+    return (((uint8_t*)&a)[0] << 24) |
+           (((uint8_t*)&a)[1] << 16) |
+           (((uint8_t*)&a)[2] <<  8) |
+           (((uint8_t*)&a)[3] <<  0);
+#endif
+}
+
+static inline uint32_t lfs_tobe32(uint32_t a) {
+    return lfs_frombe32(a);
+}
+
+// Calculate CRC-32 with polynomial = 0x04c11db7
+uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
+
+// Allocate memory, only used if buffers are not provided to littlefs
+// Note, memory must be 64-bit aligned
+static inline void *lfs_malloc(size_t size) {
+#ifndef LFS_NO_MALLOC
+    return malloc(size);
+#else
+    (void)size;
+    return NULL;
+#endif
+}
+
+// Deallocate memory, only used if buffers are not provided to littlefs
+static inline void lfs_free(void *p) {
+#ifndef LFS_NO_MALLOC
+    free(p);
+#else
+    (void)p;
+#endif
+}
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif

--- a/src/f4/app_control/source/command.c
+++ b/src/f4/app_control/source/command.c
@@ -6,7 +6,7 @@
 #include "opd.h"
 #include "time_sync.h"
 #include "max7310.h"
-#include "mmc.h"
+#include "test_mmc.h"
 #include "chprintf.h"
 #include "shell.h"
 

--- a/src/f4/app_control/source/mmc.c
+++ b/src/f4/app_control/source/mmc.c
@@ -1,11 +1,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "ch.h"
+#include "hal.h"
 #include "mmc.h"
-#include "lfs.h"
-#include "chprintf.h"
-
-#define SDC_BURST_SIZE      16
 
 /*
  * SDIO configuration.
@@ -14,9 +12,87 @@ static const SDCConfig sdccfg = {
   SDC_MODE_4BIT
 };
 
-static lfs_t lfs;
-static lfs_file_t file;
+unpacked_mmc_cid_t mmc_cid;
+unpacked_mmc_csd_t mmc_csd;
 
+/*
+ * LFS object and configuration.
+ */
+lfs_t lfs;
+
+struct lfs_config lfscfg = {
+    .context = SDC,
+    /* Block device operations */
+    .read  = mmc_read,
+    .prog  = mmc_prog,
+    .erase = mmc_erase,
+    .sync  = mmc_sync,
+
+    /* Block device configuration */
+    .read_size = 16,                /* TODO: Check these values */
+    .prog_size = 16,                /* TODO: Check these values */
+    .block_cycles = -1,             /* Disable wear leveling by LFS */
+    .cache_size = 16,               /* TODO: Check these values */
+    .lookahead_size = 16,           /* TODO: Check these values */
+};
+
+/*===========================================================================*/
+/* eMMC Support Functions                                                    */
+/*===========================================================================*/
+int mmc_enable(void)
+{
+    int err;
+    BlockDeviceInfo bdinfo;
+
+    /* Enable power to eMMC */
+    palClearLine(LINE_MMC_PWR);
+
+    /* Initializes MMC SDC interface */
+    sdcStart(SDC, &sdccfg);
+
+    /* Connect to eMMC device */
+    if (blkConnect(SDC)) {
+        return LFS_ERR_IO;
+    }
+
+    /* Clear error flags from connecting */
+    sdcGetAndClearErrors(SDC);
+
+    /* Retrieve block information */
+    blkGetInfo(SDC, &bdinfo);
+    lfscfg.block_size = bdinfo.blk_size;
+    lfscfg.block_count = bdinfo.blk_num;
+
+    /* Fetch info about eMMC device */
+    _mmcsd_unpack_mmc_cid((MMCSDBlockDevice*)SDC, &mmc_cid);
+    _mmcsd_unpack_csd_mmc((MMCSDBlockDevice*)SDC, &mmc_csd);
+
+    /* Mount LFS file system */
+    err = lfs_mount(&lfs, &lfscfg);
+
+    return err;
+}
+
+void mmc_disable(void)
+{
+    /* Unmount LFS file system */
+    lfs_unmount(&lfs);
+
+    /* Disconnect from eMMC device */
+    blkDisconnect(SDC);
+
+    /* Stop MMC SDC interface */
+    sdcStop(SDC);
+
+    /* Disable power to eMMC */
+    palSetLine(LINE_MMC_PWR);
+
+    return;
+}
+
+/*===========================================================================*/
+/* LFS Support Functions                                                     */
+/*===========================================================================*/
 int mmc_read(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size)
 {
     SDCDriver *sdcp = cfg->context;
@@ -116,267 +192,3 @@ int mmc_sync(const struct lfs_config *cfg)
     return LFS_ERR_OK;
 }
 
-/*
- * LFS configuration.
- */
-static struct lfs_config lfscfg = {
-    .context = &SDCD1,
-    /* Block device operations */
-    .read  = mmc_read,
-    .prog  = mmc_prog,
-    .erase = mmc_erase,
-    .sync  = mmc_sync,
-
-    /* Block device configuration */
-    .read_size = 16,                /* TODO: Check these values */
-    .prog_size = 16,                /* TODO: Check these values */
-    .block_cycles = -1,             /* Disable wear leveling by LFS */
-    .cache_size = 16,               /* TODO: Check these values */
-    .lookahead_size = 16,           /* TODO: Check these values */
-};
-
-/* Buffer for block read/write operations, note that extra bytes are
-   allocated in order to support unaligned operations.*/
-static uint8_t buf[MMCSD_BLOCK_SIZE * SDC_BURST_SIZE + 4];
-
-/* Additional buffer for sdcErase() test */
-static uint8_t buf2[MMCSD_BLOCK_SIZE * SDC_BURST_SIZE ];
-
-/*===========================================================================*/
-/* SD Card Control                                                           */
-/*===========================================================================*/
-void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
-    static BlockDeviceInfo bdinfo;
-    static unpacked_mmc_cid_t cid;
-    static unpacked_mmc_csd_t csd;
-    systime_t start, end;
-    uint32_t n, startblk;
-
-    if (argc < 1) {
-        chprintf(chp,  "Usage: mmc <command>\r\n"
-                       "    enable:             Enable eMMC subsystem\r\n"
-                       "    disable:            Disable eMMC subsystem\r\n"
-                       "\r\n"
-                       "    mount:              Mount LFS\r\n"
-                       "    unmount:            Unmount LFS\r\n"
-                       "    format:             Format eMMC for LFS\r\n"
-                       "\r\n"
-                       "    testread:           Test read functionality\r\n"
-                       "    testwrite:          Test write functionality\r\n"
-                       "    testall:            Test all functionality\r\n");
-        return;
-    }
-
-    if (strcmp(argv[0], "enable") == 0) {
-        chprintf(chp, "Enabling eMMC... ");
-
-        /* Enable power to eMMC */
-        palClearLine(LINE_MMC_PWR);
-
-        /* Initializes MMC SDC interface */
-        sdcStart(&SDCD1, &sdccfg);
-
-        /* Connect to eMMC device */
-        if (blkConnect(&SDCD1)) {
-            chprintf(chp, "failed\r\n");
-            return;
-        }
-
-        /* Clear error flags from connecting */
-        sdcGetAndClearErrors(&SDCD1);
-
-        /* Fetch info about eMMC device */
-        blkGetInfo(&SDCD1, &bdinfo);
-        lfscfg.block_size = bdinfo.blk_size;
-        lfscfg.block_count = bdinfo.blk_num;
-        _mmcsd_unpack_mmc_cid((MMCSDBlockDevice*)&SDCD1, &cid);
-        _mmcsd_unpack_csd_mmc((MMCSDBlockDevice*)&SDCD1, &csd);
-
-        /* Print details of the device */
-        chprintf(chp, "OK\r\n\r\nDevice Info\r\n");
-        chprintf(chp, "CSD      : %08X %8X %08X %08X \r\n",
-                SDCD1.csd[3], SDCD1.csd[2], SDCD1.csd[1], SDCD1.csd[0]);
-        chprintf(chp, "CID      : %08X %8X %08X %08X \r\n",
-                SDCD1.cid[3], SDCD1.cid[2], SDCD1.cid[1], SDCD1.cid[0]);
-        chprintf(chp, "Capacity : %DMB\r\n", SDCD1.capacity / 2048);
-        chprintf(chp, "BlockSize: %d\r\n", bdinfo.blk_size);
-        chprintf(chp, "BlockCnt : %d\r\n", bdinfo.blk_num);
-        chprintf(chp, "\r\n");
-
-        return;
-    } else if (strcmp(argv[0], "disable") == 0) {
-        chprintf(chp, "Disabling eMMC... ");
-
-        /* Disconnect from eMMC device */
-        blkDisconnect(&SDCD1);
-
-        /* Stop MMC SDC interface */
-        sdcStop(&SDCD1);
-
-        /* Disable power to eMMC */
-        palSetLine(LINE_MMC_PWR);
-
-        chprintf(chp, "OK\r\n");
-        return;
-    }
-
-    if (SDCD1.state != BLK_READY) {
-        chprintf(chp, "Error: Please enable eMMC subsystem first\r\n");
-        return;
-    }
-
-    if (!strcmp(argv[0], "mount")) {
-        int err;
-
-        chprintf(chp, "Attempting to mount LFS...\r\n");
-        err = lfs_mount(&lfs, &lfscfg);
-        if (err < 0) {
-            chprintf(chp, "Mount failed: %d\r\n", err);
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-    } else if (!strcmp(argv[0], "unmount")) {
-        int err;
-
-        chprintf(chp, "Attempting to unmount LFS...\r\n");
-        err = lfs_unmount(&lfs);
-        if (err < 0) {
-            chprintf(chp, "Unmount failed: %d\r\n", err);
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-    } else if (!strcmp(argv[0], "format")) {
-        int err;
-
-        chprintf(chp, "Attempting to format LFS...\r\n");
-        err = lfs_format(&lfs, &lfscfg);
-        if (err < 0) {
-            chprintf(chp, "Format failed: %d\r\n", err);
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-    }
-
-    /* The test is performed in the middle of the flash area.*/
-    startblk = (SDCD1.capacity / MMCSD_BLOCK_SIZE) / 2;
-    if ((strcmp(argv[0], "testread") == 0) ||
-        (strcmp(argv[0], "testall") == 0)) {
-
-        /* Single block read performance, aligned.*/
-        chprintf(chp, "Single block aligned read performance:           ");
-        start = chVTGetSystemTime();
-        end = chTimeAddX(start, TIME_MS2I(1000));
-        n = 0;
-        do {
-            if (blkRead(&SDCD1, startblk, buf, 1)) {
-                chprintf(chp, "failed\r\n");
-                return;
-            }
-            n++;
-        } while (chVTIsSystemTimeWithin(start, end));
-        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
-
-        /* Multiple sequential blocks read performance, aligned.*/
-        chprintf(chp, "16 sequential blocks aligned read performance:   ");
-        start = chVTGetSystemTime();
-        end = chTimeAddX(start, TIME_MS2I(1000));
-        n = 0;
-        do {
-            if (blkRead(&SDCD1, startblk, buf, SDC_BURST_SIZE)) {
-                chprintf(chp, "failed\r\n");
-                return;
-            }
-            n += SDC_BURST_SIZE;
-        } while (chVTIsSystemTimeWithin(start, end));
-        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
-
-#if STM32_SDC_SDIO_UNALIGNED_SUPPORT
-        /* Single block read performance, unaligned.*/
-        chprintf(chp, "Single block unaligned read performance:         ");
-        start = chVTGetSystemTime();
-        end = chTimeAddX(start, TIME_MS2I(1000));
-        n = 0;
-        do {
-            if (blkRead(&SDCD1, startblk, buf + 1, 1)) {
-                chprintf(chp, "failed\r\n");
-                return;
-            }
-            n++;
-        } while (chVTIsSystemTimeWithin(start, end));
-        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
-
-        /* Multiple sequential blocks read performance, unaligned.*/
-        chprintf(chp, "16 sequential blocks unaligned read performance: ");
-        start = chVTGetSystemTime();
-        end = chTimeAddX(start, TIME_MS2I(1000));
-        n = 0;
-        do {
-            if (blkRead(&SDCD1, startblk, buf + 1, SDC_BURST_SIZE)) {
-                chprintf(chp, "failed\r\n");
-                return;
-            }
-            n += SDC_BURST_SIZE;
-        } while (chVTIsSystemTimeWithin(start, end));
-        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
-#endif /* STM32_SDC_SDIO_UNALIGNED_SUPPORT */
-    }
-
-    if ((strcmp(argv[0], "testwrite") == 0) ||
-        (strcmp(argv[0], "testall") == 0)) {
-        uint8_t backup[MMCSD_BLOCK_SIZE * 2];
-
-        /* Backup data */
-        blkRead(&SDCD1, startblk, backup, 2);
-
-        memset(buf, 0xAA, MMCSD_BLOCK_SIZE * 2);
-        chprintf(chp, "Writing...");
-        if(blkWrite(&SDCD1, startblk, buf, 2)) {
-            chprintf(chp, "failed\r\n");
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-
-        memset(buf2, 0x55, MMCSD_BLOCK_SIZE * 2);
-        chprintf(chp, "Reading...");
-        if (blkRead(&SDCD1, startblk, buf2, 1)) {
-            chprintf(chp, "failed\r\n");
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-
-        chprintf(chp, "Comparing...");
-        if(memcmp(buf, buf2, MMCSD_BLOCK_SIZE) != 0) {
-            chprintf(chp, "Compare failed\r\n");
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-
-        for (unsigned int i = 0; i < MMCSD_BLOCK_SIZE; i++) {
-            buf[i] = i + 8;
-        }
-        chprintf(chp, "Writing...");
-        if(blkWrite(&SDCD1, startblk, buf, 2)) {
-            chprintf(chp, "failed\r\n");
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-
-        memset(buf2, 0, MMCSD_BLOCK_SIZE * 2);
-        chprintf(chp, "Reading...");
-        if (blkRead(&SDCD1, startblk, buf2, 1)) {
-            chprintf(chp, "failed\r\n");
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-
-        chprintf(chp, "Comparing...");
-        if(memcmp(buf, buf2, MMCSD_BLOCK_SIZE) != 0) {
-            chprintf(chp, "Compare failed\r\n");
-            return;
-        }
-        chprintf(chp, "OK\r\n");
-
-        /* Restore data */
-        blkWrite(&SDCD1, startblk, backup, 2);
-    }
-}

--- a/src/f4/app_control/source/mmc.c
+++ b/src/f4/app_control/source/mmc.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "mmc.h"
+#include "lfs.h"
 #include "chprintf.h"
 
 #define SDC_BURST_SIZE      16
@@ -11,6 +12,109 @@
  */
 static const SDCConfig sdccfg = {
   SDC_MODE_4BIT
+};
+
+int mmc_read(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size)
+{
+    SDCDriver *sdcp = cfg->context;
+    uint8_t *buf;
+
+    /* Sanity checks */
+    chDbgCheck(off % cfg->read_size == 0);
+    chDbgCheck(size % cfg->read_size == 0);
+    chDbgCheck(off + size < cfg->block_size);
+    chDbgCheck(block < cfg->block_count);
+
+    /* Allocate buffer */
+    buf = calloc(cfg->block_size, sizeof(uint8_t));
+    if (buf == NULL) {
+        return LFS_ERR_NOMEM;
+    }
+
+    /* Read data from block */
+    if (blkRead(sdcp, block, buf, 1) != HAL_SUCCESS) {
+        return LFS_ERR_IO;
+    }
+
+    /* Copy the requested data to the buffer */
+    memcpy(buffer, &buf[off], size);
+
+    /* Free temporary buffer */
+    free(buf);
+
+    return LFS_ERR_OK;
+}
+
+int mmc_prog(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
+{
+    SDCDriver *sdcp = cfg->context;
+    uint8_t *buf;
+
+    /* Sanity checks */
+    chDbgCheck(off % cfg->read_size == 0);
+    chDbgCheck(size % cfg->read_size == 0);
+    chDbgCheck(off + size < cfg->block_size);
+    chDbgCheck(block < cfg->block_count);
+
+    /* Allocate buffer */
+    buf = calloc(cfg->block_size, sizeof(uint8_t));
+    if (buf == NULL) {
+        return LFS_ERR_NOMEM;
+    }
+
+    /* Copy data to temp buffer */
+    memcpy(&buf[off], buffer, size);
+
+    /* Write data to block */
+    if (blkWrite(sdcp, block, buf, 1) != HAL_SUCCESS) {
+        return LFS_ERR_IO;
+    }
+
+    /* Free temporary buffer */
+    free(buf);
+
+    return LFS_ERR_OK;
+}
+
+int mmc_erase(const struct lfs_config *cfg, lfs_block_t block)
+{
+    SDCDriver *sdcp = cfg->context;
+
+    if (sdcErase(sdcp, block, block) != HAL_SUCCESS) {
+        return LFS_ERR_IO;
+    }
+
+    return LFS_ERR_OK;
+}
+
+int mmc_sync(const struct lfs_config *cfg)
+{
+    SDCDriver *sdcp = cfg->context;
+
+    if (blkSync(sdcp) != HAL_SUCCESS) {
+        return LFS_ERR_IO;
+    }
+
+    return LFS_ERR_OK;
+}
+
+/*
+ * LFS configuration.
+ */
+static struct lfs_config lfscfg = {
+    .context = &SDCD1,
+    /* Block device operations */
+    .read  = mmc_read,
+    .prog  = mmc_prog,
+    .erase = mmc_erase,
+    .sync  = mmc_sync,
+
+    /* Block device configuration */
+    .read_size = 16,                /* TODO: Check these values */
+    .prog_size = 16,                /* TODO: Check these values */
+    .block_cycles = -1,             /* Disable wear leveling by LFS */
+    .cache_size = 16,               /* TODO: Check these values */
+    .lookahead_size = 16,           /* TODO: Check these values */
 };
 
 /* Buffer for block read/write operations, note that extra bytes are
@@ -25,50 +129,81 @@ static uint8_t buf2[MMCSD_BLOCK_SIZE * SDC_BURST_SIZE ];
 /*===========================================================================*/
 void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
     static const char *mode[] = {"SDV11", "SDV20", "MMC", NULL};
+    static BlockDeviceInfo bdinfo;
     systime_t start, end;
     uint32_t n, startblk;
 
     if (argc != 1) {
-        chprintf(chp, "Usage: mmc enable|disable|read|write|erase|all\r\n");
+        chprintf(chp, "Usage: mmc <command>\r\n"
+                      "    enable:     Enable eMMC subsystem\r\n"
+                      "    disable:    Disable eMMC subsystem\r\n"
+                      "\r\n"
+                      "    testread:   Test read functionality\r\n"
+                      "    testwrite:  Test write functionality\r\n"
+                      "    testerase:  Test erase functionality\r\n"
+                      "    testall:    Test all functionality\r\n");
         return;
     }
 
     if (strcmp(argv[0], "enable") == 0) {
-        /* Initializes MMC SDC interface */
+        chprintf(chp, "Enabling eMMC... ");
+
+        /* Enable power to eMMC */
         palClearLine(LINE_MMC_PWR);
+
+        /* Initializes MMC SDC interface */
         sdcStart(&SDCD1, &sdccfg);
+
+        /* Connect to eMMC device */
+        if (blkConnect(&SDCD1)) {
+            chprintf(chp, "failed\r\n");
+            return;
+        }
+
+        /* Fetch info about eMMC device */
+        blkGetInfo(&SDCD1, &bdinfo);
+        lfscfg.block_size = bdinfo.blk_size;
+        lfscfg.block_count = bdinfo.blk_num;
+
+        chprintf(chp, "OK\r\n\r\nCard Info\r\n");
+        chprintf(chp, "CSD      : %08X %8X %08X %08X \r\n",
+                SDCD1.csd[3], SDCD1.csd[2], SDCD1.csd[1], SDCD1.csd[0]);
+        chprintf(chp, "CID      : %08X %8X %08X %08X \r\n",
+                SDCD1.cid[3], SDCD1.cid[2], SDCD1.cid[1], SDCD1.cid[0]);
+        chprintf(chp, "Mode     : %s\r\n", mode[SDCD1.cardmode & 3U]);
+        chprintf(chp, "Capacity : %DMB\r\n", SDCD1.capacity / 2048);
+        chprintf(chp, "BlockSize: %d\r\n", bdinfo.blk_size);
+        chprintf(chp, "BlockCnt : %d\r\n", bdinfo.blk_num);
+
+
+        chprintf(chp, "done!\r\n");
         return;
     } else if (strcmp(argv[0], "disable") == 0) {
+        chprintf(chp, "Disabling eMMC... ");
+
+        /* Disconnect from eMMC device */
+        blkDisconnect(&SDCD1);
+
+        /* Stop MMC SDC interface */
         sdcStop(&SDCD1);
+
+        /* Disable power to eMMC */
         palSetLine(LINE_MMC_PWR);
+
+        chprintf(chp, "done!\r\n");
         return;
     }
 
     if (SDCD1.state != BLK_READY) {
-        chprintf(chp, "Please enable eMMC subsystem first\r\n");
+        chprintf(chp, "Error: Please enable eMMC subsystem first\r\n");
         return;
     }
-
-    /* Connection to the card.*/
-    chprintf(chp, "Connecting... ");
-    if (sdcConnect(&SDCD1)) {
-        chprintf(chp, "failed\r\n");
-        return;
-    }
-
-    chprintf(chp, "OK\r\n\r\nCard Info\r\n");
-    chprintf(chp, "CSD      : %08X %8X %08X %08X \r\n",
-            SDCD1.csd[3], SDCD1.csd[2], SDCD1.csd[1], SDCD1.csd[0]);
-    chprintf(chp, "CID      : %08X %8X %08X %08X \r\n",
-            SDCD1.cid[3], SDCD1.cid[2], SDCD1.cid[1], SDCD1.cid[0]);
-    chprintf(chp, "Mode     : %s\r\n", mode[SDCD1.cardmode & 3U]);
-    chprintf(chp, "Capacity : %DMB\r\n", SDCD1.capacity / 2048);
 
     /* The test is performed in the middle of the flash area.*/
     startblk = (SDCD1.capacity / MMCSD_BLOCK_SIZE) / 2;
 
-    if ((strcmp(argv[0], "read") == 0) ||
-        (strcmp(argv[0], "all") == 0)) {
+    if ((strcmp(argv[0], "testread") == 0) ||
+        (strcmp(argv[0], "testall") == 0)) {
 
         /* Single block read performance, aligned.*/
         chprintf(chp, "Single block aligned read performance:           ");
@@ -78,7 +213,7 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
         do {
             if (blkRead(&SDCD1, startblk, buf, 1)) {
                 chprintf(chp, "failed\r\n");
-                goto exittest;
+                return;
             }
             n++;
         } while (chVTIsSystemTimeWithin(start, end));
@@ -92,7 +227,7 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
         do {
             if (blkRead(&SDCD1, startblk, buf, SDC_BURST_SIZE)) {
                 chprintf(chp, "failed\r\n");
-                goto exittest;
+                return;
             }
             n += SDC_BURST_SIZE;
         } while (chVTIsSystemTimeWithin(start, end));
@@ -107,7 +242,7 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
         do {
             if (blkRead(&SDCD1, startblk, buf + 1, 1)) {
                 chprintf(chp, "failed\r\n");
-                goto exittest;
+                return;
             }
             n++;
         } while (chVTIsSystemTimeWithin(start, end));
@@ -121,7 +256,7 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
         do {
             if (blkRead(&SDCD1, startblk, buf + 1, SDC_BURST_SIZE)) {
                 chprintf(chp, "failed\r\n");
-                goto exittest;
+                return;
             }
             n += SDC_BURST_SIZE;
         } while (chVTIsSystemTimeWithin(start, end));
@@ -129,15 +264,15 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
 #endif /* STM32_SDC_SDIO_UNALIGNED_SUPPORT */
     }
 
-    if ((strcmp(argv[0], "write") == 0) ||
-        (strcmp(argv[0], "all") == 0)) {
+    if ((strcmp(argv[0], "testwrite") == 0) ||
+        (strcmp(argv[0], "testall") == 0)) {
         unsigned i;
 
         memset(buf, 0xAA, MMCSD_BLOCK_SIZE * 2);
         chprintf(chp, "Writing...");
-        if(sdcWrite(&SDCD1, startblk, buf, 2)) {
+        if(blkWrite(&SDCD1, startblk, buf, 2)) {
             chprintf(chp, "failed\r\n");
-            goto exittest;
+            return;
         }
         chprintf(chp, "OK\r\n");
 
@@ -145,16 +280,16 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
         chprintf(chp, "Reading...");
         if (blkRead(&SDCD1, startblk, buf, 1)) {
             chprintf(chp, "failed\r\n");
-            goto exittest;
+            return;
         }
         chprintf(chp, "OK\r\n");
 
         for (i = 0; i < MMCSD_BLOCK_SIZE; i++)
             buf[i] = i + 8;
         chprintf(chp, "Writing...");
-        if(sdcWrite(&SDCD1, startblk, buf, 2)) {
+        if(blkWrite(&SDCD1, startblk, buf, 2)) {
             chprintf(chp, "failed\r\n");
-            goto exittest;
+            return;
         }
         chprintf(chp, "OK\r\n");
 
@@ -162,13 +297,13 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
         chprintf(chp, "Reading...");
         if (blkRead(&SDCD1, startblk, buf, 1)) {
             chprintf(chp, "failed\r\n");
-            goto exittest;
+            return;
         }
         chprintf(chp, "OK\r\n");
     }
 
-    if ((strcmp(argv[0], "erase") == 0) ||
-        (strcmp(argv[0], "all") == 0)) {
+    if ((strcmp(argv[0], "testerase") == 0) ||
+        (strcmp(argv[0], "testall") == 0)) {
         /**
          * Test sdcErase()
          * Strategy:
@@ -189,58 +324,54 @@ void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
             buf[i] = (i + 7) % 'T'; //Ensure block 1/2 are not equal
         }
         /* 2. */
-        if(sdcWrite(&SDCD1, startblk, buf, 2)) {
+        if(blkWrite(&SDCD1, startblk, buf, 2)) {
             chprintf(chp, "sdcErase() test write failed\r\n");
-            goto exittest;
+            return;
         }
         /* 3. (erase) */
         if(sdcErase(&SDCD1, startblk + 1, startblk + 2)) {
             chprintf(chp, "sdcErase() failed\r\n");
-            goto exittest;
+            return;
         }
         sdcflags_t errflags = sdcGetAndClearErrors(&SDCD1);
         if(errflags) {
             chprintf(chp, "sdcErase() yielded error flags: %d\r\n", errflags);
-            goto exittest;
+            return;
         }
-        if(sdcRead(&SDCD1, startblk, buf2, 2)) {
+        if(blkRead(&SDCD1, startblk, buf2, 2)) {
             chprintf(chp, "single-block mmcErase() failed\r\n");
-            goto exittest;
+            return;
         }
         /* 3.1. */
         if(memcmp(buf, buf2, MMCSD_BLOCK_SIZE) != 0) {
             chprintf(chp, "sdcErase() non-erased block compare failed\r\n");
-            goto exittest;
+            return;
         }
         /* 3.2. */
         if(memcmp(buf + MMCSD_BLOCK_SIZE,
                     buf2 + MMCSD_BLOCK_SIZE, MMCSD_BLOCK_SIZE) == 0) {
             chprintf(chp, "sdcErase() erased block compare failed\r\n");
-            goto exittest;
+            return;
         }
         /* 4. */
         if(sdcErase(&SDCD1, startblk, startblk + 2)) {
             chprintf(chp, "multi-block sdcErase() failed\r\n");
-            goto exittest;
+            return;
         }
-        if(sdcRead(&SDCD1, startblk, buf2, 2)) {
+        if(blkRead(&SDCD1, startblk, buf2, 2)) {
             chprintf(chp, "single-block sdcErase() failed\r\n");
-            goto exittest;
+            return;
         }
         /* 4.1 */
         if(memcmp(buf, buf2, MMCSD_BLOCK_SIZE) == 0) {
             chprintf(chp, "multi-block sdcErase() erased block compare failed\r\n");
-            goto exittest;
+            return;
         }
         if(memcmp(buf + MMCSD_BLOCK_SIZE,
                   buf2 + MMCSD_BLOCK_SIZE, MMCSD_BLOCK_SIZE) == 0) {
             chprintf(chp, "multi-block sdcErase() erased block compare failed\r\n");
-            goto exittest;
+            return;
         }
         /* END of sdcErase() test */
     }
-
-    /* Card disconnect and command end.*/
-exittest:
-    sdcDisconnect(&SDCD1);
 }

--- a/src/f4/app_control/source/mmc.h
+++ b/src/f4/app_control/source/mmc.h
@@ -1,14 +1,23 @@
 #ifndef _MMC_H_
 #define _MMC_H_
 
+#include "lfs.h"
+
+#define SDC (&SDCD1)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "ch.h"
-#include "hal.h"
+/* eMMC support functions */
+int mmc_enable(void);
+void mmc_disable(void);
 
-void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]);
+/* LFS support functions */
+int mmc_read(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size);
+int mmc_prog(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size);
+int mmc_erase(const struct lfs_config *cfg, lfs_block_t block);
+int mmc_sync(const struct lfs_config *cfg);
 
 #ifdef __cplusplus
 }

--- a/src/f4/app_control/source/test_mmc.c
+++ b/src/f4/app_control/source/test_mmc.c
@@ -1,0 +1,228 @@
+#include <string.h>
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+#include "mmc.h"
+
+#define SDC_BURST_SIZE      16
+
+extern lfs_t lfs;
+extern struct lfs_config lfscfg;
+
+/* Buffer for block read/write operations, note that extra bytes are
+   allocated in order to support unaligned operations.*/
+static uint8_t buf[MMCSD_BLOCK_SIZE * SDC_BURST_SIZE + 4];
+
+/* Additional buffer for sdcErase() test */
+static uint8_t buf2[MMCSD_BLOCK_SIZE * SDC_BURST_SIZE ];
+
+/*===========================================================================*/
+/* eMMC Testing                                                              */
+/*===========================================================================*/
+void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]) {
+    systime_t start, end;
+    uint32_t n, startblk;
+
+    if (argc < 1) {
+        chprintf(chp,  "Usage: mmc <command>\r\n"
+                       "    enable:             Enable eMMC subsystem\r\n"
+                       "    disable:            Disable eMMC subsystem\r\n"
+                       "\r\n"
+                       "    mount:              Mount LFS\r\n"
+                       "    unmount:            Unmount LFS\r\n"
+                       "    format:             Format eMMC for LFS\r\n"
+                       "\r\n"
+                       "    testread:           Test read functionality\r\n"
+                       "    testwrite:          Test write functionality\r\n"
+                       "    testall:            Test all functionality\r\n");
+        return;
+    }
+
+    if (strcmp(argv[0], "enable") == 0) {
+        chprintf(chp, "Enabling eMMC... ");
+
+        if (mmc_enable()) {
+            chprintf(chp, "failed\r\n");
+            return;
+        }
+
+        /* Print details of the device */
+        chprintf(chp, "OK\r\n\r\nDevice Info\r\n");
+        chprintf(chp, "CSD      : %08X %8X %08X %08X \r\n",
+                SDC->csd[3], SDC->csd[2], SDC->csd[1], SDC->csd[0]);
+        chprintf(chp, "CID      : %08X %8X %08X %08X \r\n",
+                SDC->cid[3], SDC->cid[2], SDC->cid[1], SDC->cid[0]);
+        chprintf(chp, "Capacity : %DMB\r\n", SDC->capacity / 2048);
+        chprintf(chp, "\r\n");
+
+        return;
+    } else if (strcmp(argv[0], "disable") == 0) {
+        chprintf(chp, "Disabling eMMC... ");
+
+        mmc_disable();
+
+        chprintf(chp, "OK\r\n");
+        return;
+    }
+
+    if (SDC->state != BLK_READY) {
+        chprintf(chp, "Error: Please enable eMMC subsystem first\r\n");
+        return;
+    }
+
+    if (!strcmp(argv[0], "mount")) {
+        int err;
+
+        chprintf(chp, "Attempting to mount LFS...\r\n");
+        err = lfs_mount(&lfs, &lfscfg);
+        if (err < 0) {
+            chprintf(chp, "Mount failed: %d\r\n", err);
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+    } else if (!strcmp(argv[0], "unmount")) {
+        int err;
+
+        chprintf(chp, "Attempting to unmount LFS...\r\n");
+        err = lfs_unmount(&lfs);
+        if (err < 0) {
+            chprintf(chp, "Unmount failed: %d\r\n", err);
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+    } else if (!strcmp(argv[0], "format")) {
+        int err;
+
+        chprintf(chp, "Attempting to format LFS...\r\n");
+        err = lfs_format(&lfs, &lfscfg);
+        if (err < 0) {
+            chprintf(chp, "Format failed: %d\r\n", err);
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+    }
+
+    /* The test is performed in the middle of the flash area.*/
+    startblk = (SDC->capacity / MMCSD_BLOCK_SIZE) / 2;
+    if ((strcmp(argv[0], "testread") == 0) ||
+        (strcmp(argv[0], "testall") == 0)) {
+
+        /* Single block read performance, aligned.*/
+        chprintf(chp, "Single block aligned read performance:           ");
+        start = chVTGetSystemTime();
+        end = chTimeAddX(start, TIME_MS2I(1000));
+        n = 0;
+        do {
+            if (blkRead(SDC, startblk, buf, 1)) {
+                chprintf(chp, "failed\r\n");
+                return;
+            }
+            n++;
+        } while (chVTIsSystemTimeWithin(start, end));
+        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
+
+        /* Multiple sequential blocks read performance, aligned.*/
+        chprintf(chp, "16 sequential blocks aligned read performance:   ");
+        start = chVTGetSystemTime();
+        end = chTimeAddX(start, TIME_MS2I(1000));
+        n = 0;
+        do {
+            if (blkRead(SDC, startblk, buf, SDC_BURST_SIZE)) {
+                chprintf(chp, "failed\r\n");
+                return;
+            }
+            n += SDC_BURST_SIZE;
+        } while (chVTIsSystemTimeWithin(start, end));
+        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
+
+#if STM32_SDC_SDIO_UNALIGNED_SUPPORT
+        /* Single block read performance, unaligned.*/
+        chprintf(chp, "Single block unaligned read performance:         ");
+        start = chVTGetSystemTime();
+        end = chTimeAddX(start, TIME_MS2I(1000));
+        n = 0;
+        do {
+            if (blkRead(SDC, startblk, buf + 1, 1)) {
+                chprintf(chp, "failed\r\n");
+                return;
+            }
+            n++;
+        } while (chVTIsSystemTimeWithin(start, end));
+        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
+
+        /* Multiple sequential blocks read performance, unaligned.*/
+        chprintf(chp, "16 sequential blocks unaligned read performance: ");
+        start = chVTGetSystemTime();
+        end = chTimeAddX(start, TIME_MS2I(1000));
+        n = 0;
+        do {
+            if (blkRead(SDC, startblk, buf + 1, SDC_BURST_SIZE)) {
+                chprintf(chp, "failed\r\n");
+                return;
+            }
+            n += SDC_BURST_SIZE;
+        } while (chVTIsSystemTimeWithin(start, end));
+        chprintf(chp, "%D blocks/S, %D bytes/S\r\n", n, n * MMCSD_BLOCK_SIZE);
+#endif /* STM32_SDC_SDIO_UNALIGNED_SUPPORT */
+    }
+
+    if ((strcmp(argv[0], "testwrite") == 0) ||
+        (strcmp(argv[0], "testall") == 0)) {
+        uint8_t backup[MMCSD_BLOCK_SIZE * 2];
+
+        /* Backup data */
+        blkRead(SDC, startblk, backup, 2);
+
+        memset(buf, 0xAA, MMCSD_BLOCK_SIZE * 2);
+        chprintf(chp, "Writing...");
+        if(blkWrite(SDC, startblk, buf, 2)) {
+            chprintf(chp, "failed\r\n");
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+
+        memset(buf2, 0x55, MMCSD_BLOCK_SIZE * 2);
+        chprintf(chp, "Reading...");
+        if (blkRead(SDC, startblk, buf2, 1)) {
+            chprintf(chp, "failed\r\n");
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+
+        chprintf(chp, "Comparing...");
+        if(memcmp(buf, buf2, MMCSD_BLOCK_SIZE) != 0) {
+            chprintf(chp, "Compare failed\r\n");
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+
+        for (unsigned int i = 0; i < MMCSD_BLOCK_SIZE; i++) {
+            buf[i] = i + 8;
+        }
+        chprintf(chp, "Writing...");
+        if(blkWrite(SDC, startblk, buf, 2)) {
+            chprintf(chp, "failed\r\n");
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+
+        memset(buf2, 0, MMCSD_BLOCK_SIZE * 2);
+        chprintf(chp, "Reading...");
+        if (blkRead(SDC, startblk, buf2, 1)) {
+            chprintf(chp, "failed\r\n");
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+
+        chprintf(chp, "Comparing...");
+        if(memcmp(buf, buf2, MMCSD_BLOCK_SIZE) != 0) {
+            chprintf(chp, "Compare failed\r\n");
+            return;
+        }
+        chprintf(chp, "OK\r\n");
+
+        /* Restore data */
+        blkWrite(SDC, startblk, backup, 2);
+    }
+}

--- a/src/f4/app_control/source/test_mmc.h
+++ b/src/f4/app_control/source/test_mmc.h
@@ -1,0 +1,16 @@
+#ifndef _TEST_MMC_H_
+#define _TEST_MMC_H_
+
+#include "ch.h"
+#include "hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void cmd_mmc(BaseSequentialStream *chp, int argc, char *argv[]);
+
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
+#endif


### PR DESCRIPTION
This implements the [littlefs](https://github.com/ARMmbed/littlefs) file system for data storage on OreSat (specifically in C3). It abstracts out eMMC functionality and LFS implementation to allow users to utilize the LFS file IO operations on a global `lfs` object.

Resolves #35