### PR TITLE
Docker toolchain

### DIFF
--- a/doc/docker-toolchain.md
+++ b/doc/docker-toolchain.md
@@ -1,0 +1,60 @@
+# Docker Toolchain
+
+OreSat fimware toolchain in a docker container.
+
+This allows a developer to modify any source code with their favorite IDE or
+text editor and then compile the code in the docker container without needing
+to build the toolchain for their specific systems and allows all oresat fimware
+developers to have the exact same toolchain reguardless of their developing
+system's OS.
+
+The container only contains the toolchain no `oresat-fimware` source code, so
+the source needs to be add as volume to the container when the container is used.
+
+The [docker-toolchain.sh] script is for convience rather than having to type a
+long docker command every time the source code needs to be compiled. The script
+will add the `oresat-fimware` directory to the container allow the fimware to
+be compiled in the container. For Linux host **only**, it also can automatically
+detect any STLINK programmers and add them to the container, allowing the docker
+container to flash images to hardware. Docker for Windows and Mac host does not
+support USB pass-though, so the [docker-toolchain.sh] cannot flash images when
+used on a Windows or Mac host.
+
+## Setup
+
+- **Linux users only**:
+  - Make sure `usbutils` is install on your system, install it if not.
+  - Install `docker` for your system
+  - Enable and start docker daemon:
+    - `$ sudo systemctl enable docker`
+    - `$ sudo systemctl start docker`
+  - Add your user to the `docker` group, so `sudo` will not be require for all
+    `docker` commands. Replace `USERNAME` with your username:
+    `$ sudo usermod -aG docker USERNAME`
+  - Log out or reboot your system for the new group to take effect
+- **Mac users only**:
+  - Install `docker`, see https://docs.docker.com/desktop/mac/install/
+- **Windows users only**:
+  - Install `docker`, see https://docs.docker.com/desktop/windows/install/
+- Clone oresat-fimware repo:
+  `$ git clone --recurse-submodules git:https://github.com:oresat/oresat-fimware.git`
+- Swap to oresat-fimware directory: `$ cd oresat-fimware`
+- Pull and test docker toolchain by building an app:
+  `$ ./docker-toolchain.sh build src/f0/app_blinky`
+  - **NOTE:** This will automatically pull the docker image on first run
+
+## Usage
+
+- Must be in the root directory of the `oresat-fimware` repo.
+- Use the Docker toolchain: `$ ./docker-toolchain.sh COMMAND APP SERIAL`.
+  - **NOTE:** `SERIAL` is an optional arg for `write` and `gdb` commands to specify
+    which stlink to use in case of multiple stlinks.
+- Examples:
+  - `$ ./docker-toolchain.sh info`
+  - `$ ./docker-toolchain.sh build src/f0/app_solar`
+  - `$ ./docker-toolchain.sh write src/f0/app_solar`
+  - `$ ./docker-toolchain.sh write src/f0/app_solar 0123456789ABCDEF`
+  - `$ ./docker-toolchain.sh gdb src/f0/app_solar`
+  - `$ ./docker-toolchain.sh gdb src/f0/app_solar 0123456789ABCDEF`
+
+[docker-toolchain.sh]: ../docker-toolchain.sh

--- a/docker-toolchain.sh
+++ b/docker-toolchain.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+help_msg() {
+    echo "OreSat firmware docker toolchain"
+    echo "Usage: ./docker-toolchain.sh command path_to_app [options]..."
+    echo "Command options:"
+    echo "  help                        This message"
+    echo "  info                        Get the output of \"st-info --probe\""
+    echo "  build                       Build an image"
+    echo "  write                       Write an image"
+    echo "  gdb                         Run gdb"
+    echo "Options:"
+    echo "  <serial>                    Specify stlink serial for write/gdb commands."
+    echo " "
+    echo "Examples:"
+    echo "  ./docker-toolchain.sh info"
+    echo "  ./docker-toolchain.sh build src/f0/app_blinky"
+    echo "  ./docker-toolchain.sh write src/f0/app_blinky"
+    echo "  ./docker-toolchain.sh write src/f0/app_blinky 0123456789ABCDEF "
+    echo " "
+    echo "NOTE: When multiple stlinks are plug into host, use the info command"
+    echo "to get serial for the stlinks, and set the optional <serial> arg to"
+    echo "to specify to the serial for the stlink wanted."
+}
+
+# parse args
+if [[ "$1" == "build" ]]; then
+    # run as user so build/ and .dep/ dir belong to user, not root
+    docker run \
+        --rm \
+        -u `id -u`:`id -g` \
+        -v `pwd`:/oresat-firmware \
+        oresat/firmware-toolchain make clean all -C $2
+    exit 0
+elif [[ "$1" == "write" ]]; then
+    CMD="make write -C $2"
+elif [[ "$1" == "gdb" ]]; then
+    # gdb requires interactive mode
+    INTER='-it'
+    CMD="make gdb -C $2"
+elif [[ "$1" == "help" ]]; then
+    help_msg
+    exit 0
+elif [[ "$1" == "info" ]]; then
+    CMD="st-info --probe"
+else
+    echo -e "\ninvalid command"
+    help_msg
+    exit 1
+fi
+
+# write and gdb have readonly permission, so "make all" won't work
+if [[ "$1" == "write" ||  "$1" == "gdb" ]]; then
+    if [ ! -d "$2/build" ]; then
+        echo "run \"./docker-toolchain.sh build $2\" before \"./docker-toolchain.sh $1 $2\""
+        exit 1
+    fi
+fi
+
+# grab SERIAL arg if given
+if [ "$3" != "" ]; then
+    CMD="$CMD SERIAL=$3"
+fi
+
+# find all the stlink devices
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then # Linux
+    while read -r line; do
+        TEMP=`echo $line | cut -d ':' -f 1`
+        if [[ ! "$TEMP" ]]; then
+            break # nothing in line
+        fi
+        BUS=`echo $TEMP | cut -d ' ' -f 2`
+        DEV=`echo $TEMP | cut -d ' ' -f 4`
+        DEVICES="${DEVICES} --device=/dev/bus/usb/${BUS}/${DEV}"
+    done <<< `lsusb | grep -i -e "stlink" -e "st-link"`
+else
+    echo "docker usb pass-through not support on non Linux hosts"
+fi
+
+# make sure there are devices for write and gdb
+if [[ ! "$DEVICES" ]]; then
+    echo "No STLINK devices found."
+    if [[ "$1" == "write" || "$1" == "gdb" ]]; then
+        exit 1
+    fi
+fi
+
+docker run \
+    --rm \
+    $INTER \
+    -v `pwd`:/oresat-firmware:ro \
+    $DEVICES \
+    oresat/firmware-toolchain $CMD

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:bookworm-slim
+
+RUN apt update && apt -y install \
+  autoconf \
+  automake \
+  gcc-arm-none-eabi \
+  gdb-multiarch \
+  git \
+  libcapstone4 \
+  libftdi1-2 \
+  libgpiod2 \
+  libhidapi-hidraw0 \
+  libtool \
+  libusb-1.0-0 \
+  libusb-1.0-0-dev \
+  make \
+  pkg-config \
+  python3 \
+  srecord \
+  stlink-tools \
+  tcl \
+  xxd \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --recurse-submodules https://github.com/openocd-org/openocd && \
+    cd openocd && \
+    ./bootstrap && \
+    ./configure --prefix=/usr --disable-werror --enable-stlink && \
+    make && \
+    make install && \
+    cd .. && \
+    rm openocd -rf
+
+RUN mkdir /oresat-firmware
+WORKDIR /oresat-firmware
+
+RUN ln -s /usr/bin/gdb-multiarch /usr/bin/arm-none-eabi-gdb

--- a/toolchain/toolchain.mk
+++ b/toolchain/toolchain.mk
@@ -5,6 +5,10 @@ OOCD_CFG = oocd.cfg
 GDB_OOCD_CFG = gdboocd.cmd
 GDB_STL_CFG = gdbstl.cmd
 SERIAL_RAW != echo -e "$(SERIAL)"
+ifneq ($(SERIAL),)
+	SERIAL_ARG = adapter serial $(SERIAL);
+endif
+
 
 ifeq ($(USE_BOOTLOADER),yes)
 POST_MAKE_ALL_RULE_HOOK:
@@ -19,7 +23,7 @@ endif
 write: $(OUTFILES) POST_MAKE_ALL_RULE_HOOK write_ocd
 
 write_ocd:
-	openocd -s $(BOARDDIR) -f $(OOCD_CFG) -c "hla_serial $(SERIAL); program $(APP_HEXFILE) verify reset exit"
+	openocd -s $(BOARDDIR) -f $(OOCD_CFG) -c "$(SERIAL_ARG) program $(APP_HEXFILE) verify reset exit"
 
 write_stl:
 	st-flash --serial=$(SERIAL_RAW) --reset --format ihex write $(APP_HEXFILE)
@@ -27,7 +31,7 @@ write_stl:
 gdb: $(GDB_ELF) gdb_ocd
 
 gdb_ocd:
-	$(TRGT)gdb -q $(shell pwd)/$(GDB_ELF) -cd $(BOARDDIR) -ex "target remote | openocd -f oocd.cfg -c 'hla_serial $(SERIAL); gdb_port pipe'" -x $(GDB_OOCD_CFG)
+	$(TRGT)gdb -q $(shell pwd)/$(GDB_ELF) -cd $(BOARDDIR) -ex "target remote | openocd -f oocd.cfg -c '$(SERIAL_ARG) gdb_port pipe'" -x $(GDB_OOCD_CFG)
 
 gdb_stl:
 	$(TRGT)gdb -q $(shell pwd)/$(GDB_ELF) -cd $(TOOLCHAIN) -x ./$(GDB_STL_CFG)


### PR DESCRIPTION
OreSat firmware toolchain in a docker container. See `doc/docker-toolchain.md` for setup / usage. 

The good:
- This will allow all OreSat firmware developers to have the exact same toolchain (the versions of openocd, stlink, and the Arm toolchain will all be the same).
- It can be used to compile the OreSat firmware on Linux / Windows / Mac hosts.
- Linux hosts can flash / debug with it.

The bad:
- The docker toolchain is 3 GB (as the Arm toolchain is 2GB alone).
-  Only Linux hosts can flash and debug with it, as docker for Windows and Mac does not support USB pass-through.

I had to grab commit 10edf575b60fd6980b459167a015650624de4966 from the `c3_dev` branch as that contain a fix is required to compile any firmware image, not just the c3.