### PR TITLE
Make sure argv indeces exist before comparing them in test_lfs.c and test_time.c

### DIFF
--- a/src/f4/app_cantest/source/test_lfs.c
+++ b/src/f4/app_cantest/source/test_lfs.c
@@ -16,7 +16,7 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
     struct lfs_info info;
     char buf[BUF_SIZE];
 
-    if (!strcmp(argv[0], "ls") && argc > 1) {
+    if (argv[0] != NULL && !strcmp(argv[0], "ls") && argc > 1) {
         dir = dir_open(&FSD1, argv[1]);
         if (dir == NULL) {
             chprintf(chp, "Error in dir_open: %d\r\n", FSD1.err);
@@ -45,19 +45,19 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
             return;
         }
         chprintf(chp, "\r\n");
-    } else if (!strcmp(argv[0], "mkdir") && argc > 1) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "mkdir") && argc > 1) {
         ret = fs_mkdir(&FSD1, argv[1]);
         if (ret < 0) {
             chprintf(chp, "Error in fs_mkdir: %d\r\n");
             return;
         }
-    } else if (!strcmp(argv[0], "rm") && argc > 1) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "rm") && argc > 1) {
         ret = fs_remove(&FSD1, argv[1]);
         if (ret < 0) {
             chprintf(chp, "Error in fs_remove: %d\r\n");
             return;
         }
-    } else if (!strcmp(argv[0], "cat") && argc > 1) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "cat") && argc > 1) {
         file = file_open(&FSD1, argv[1], LFS_O_RDONLY);
         if (file == NULL) {
             chprintf(chp, "Error in file_open: %d\r\n", FSD1.err);
@@ -78,7 +78,7 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
             chprintf(chp, "Error in file_close: %d\r\n", ret);
             return;
         }
-    } else if (!strcmp(argv[0], "hexdump") && argc > 1) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "hexdump") && argc > 1) {
         file = file_open(&FSD1, argv[1], LFS_O_RDONLY);
         if (file == NULL) {
             chprintf(chp, "Error in file_open: %d\r\n", FSD1.err);
@@ -102,7 +102,7 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
             chprintf(chp, "Error in file_close: %d\r\n", ret);
             return;
         }
-    } else if (!strcmp(argv[0], "load") && argc > 1) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "load") && argc > 1) {
         uint8_t buf[BUF_SIZE] = {0};
         char line[BUF_SIZE * 2] = {0};
         char c, *p = line;
@@ -159,7 +159,7 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
             chprintf(chp, "Error in file_close: %d\r\n", ret);
             return;
         }
-    } else if (!strcmp(argv[0], "mount")) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "mount")) {
         chprintf(chp, "Attempting to mount LFS...\r\n");
         ret = fs_mount(&FSD1, false);
         if (ret < 0) {
@@ -167,7 +167,7 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
             return;
         }
         chprintf(chp, "OK\r\n");
-    } else if (!strcmp(argv[0], "unmount")) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "unmount")) {
         chprintf(chp, "Attempting to unmount LFS...\r\n");
         ret = fs_unmount(&FSD1);
         if (ret < 0) {
@@ -175,7 +175,7 @@ void cmd_lfs(BaseSequentialStream *chp, int argc, char *argv[])
             return;
         }
         chprintf(chp, "OK\r\n");
-    } else if (!strcmp(argv[0], "format")) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "format")) {
         chprintf(chp, "Attempting to format LFS...\r\n");
         ret = fs_format(&FSD1);
         if (ret < 0) {

--- a/src/f4/app_cantest/source/test_time.c
+++ b/src/f4/app_cantest/source/test_time.c
@@ -16,34 +16,34 @@ void cmd_time(BaseSequentialStream *chp, int argc, char *argv[])
     if (argc < 1) {
         goto time_usage;
     }
-    if (!strcmp(argv[0], "unix")) {
-        if (!strcmp(argv[1], "get")) {
+    if (argv[0] != NULL && !strcmp(argv[0], "unix")) {
+        if (argv[1] != NULL && !strcmp(argv[1], "get")) {
             time_t unix_time = rtcGetTimeUnix(&msec);
             char *timestr = ctime(&unix_time);
             chprintf(chp, "UNIX Time: %d\r\n"
                           "Date:      %s\r\n",
                           unix_time, timestr);
-        } else if (!strcmp(argv[1], "set") && argc > 2) {
+        } else if (argv[1] != NULL && !strcmp(argv[1], "set") && argc > 2) {
             rtcSetTimeUnix(strtoul(argv[2], NULL, 0), 0);
         } else {
             goto time_usage;
         }
-    } else if (!strcmp(argv[0], "scet")) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "scet")) {
         if (!strcmp(argv[1], "get")) {
             rtcGetTimeSCET(&scet);
             chprintf(chp, "SCET Time: %u.%u\r\n", scet.coarse, scet.fine);
-        } else if (!strcmp(argv[1], "set") && argc > 3) {
+        } else if (argv[1] != NULL && !strcmp(argv[1], "set") && argc > 3) {
             scet.coarse = strtoul(argv[2], NULL, 0);
             scet.fine = strtoul(argv[3], NULL, 0);
             rtcSetTimeSCET(&scet);
         } else {
             goto time_usage;
         }
-    } else if (!strcmp(argv[0], "utc")) {
+    } else if (argv[0] != NULL && !strcmp(argv[0], "utc")) {
         if (!strcmp(argv[1], "get")) {
             rtcGetTimeUTC(&utc);
             chprintf(chp, "UTC Time: Day: %u ms: %u us: %u\r\n", utc.day, utc.ms, utc.us);
-        } else if (!strcmp(argv[1], "set") && argc > 4) {
+        } else if (argv[1] != NULL && !strcmp(argv[1], "set") && argc > 4) {
             utc.day = strtoul(argv[2], NULL, 0);
             utc.ms = strtoul(argv[3], NULL, 0);
             utc.us = strtoul(argv[4], NULL, 0);
@@ -51,7 +51,7 @@ void cmd_time(BaseSequentialStream *chp, int argc, char *argv[])
         } else {
             goto time_usage;
         }
-    } else if (!strcmp(argv[0], "raw")) {
+    } else if (argv[1] != NULL && !strcmp(argv[0], "raw")) {
         rtcGetTime(&RTCD1, &timespec);
         chprintf(chp, "Year: %u Month: %u DST: %u DoW: %u Day: %u ms: %u\r\n",
                       timespec.year, timespec.month, timespec.dstflag, timespec.dayofweek, timespec.day, timespec.millisecond);


### PR DESCRIPTION
This should resolve issue #89 
- Ensures that argv values exist before attempting to strcmp them to operations
- This is far from a perfect solution -- in the future, it would be good to have this checking happen before anything else is done.