### PR TITLE
Switch from hla_swd to dapdirect_swd

### DIFF
--- a/boards/ST_NUCLEO64_F091RC/oocd.cfg
+++ b/boards/ST_NUCLEO64_F091RC/oocd.cfg
@@ -4,6 +4,6 @@
 #
 
 source [find interface/stlink.cfg]
-transport select hla_swd
+transport select dapdirect_swd
 source [find target/stm32f0x.cfg]
 


### PR DESCRIPTION
This change is compatible with ST Nucleo64 F091RC firmware versions V2J33M25 and V2J46M31.