### PR TITLE
Openocd packages are updated again in distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,6 @@ Tools required:
 To install oresat-configs:
 * `$ pip install oresat-configs`
 
-PLEASE NOTE: If you use OpenOCD, the latest "official" release of OpenOCD in
-package managers is several years old. You MUST build it from source for it
-to work with our boards, as there have been over 1000 commits since the
-last official release and several of our boards were added since then.
-
 Please refer to [Platform Specific Installation Instructions](doc/toolchain.md)
 for details on how to do this on a per-system basis.
 

--- a/doc/toolchain.md
+++ b/doc/toolchain.md
@@ -35,13 +35,4 @@ The packages needed for Debian are as follow:
 `$ sudo apt install autoconf automake gcc-arm-none-eabi gdb-multiarch
  git libcapstone4 libftdi1-2 libgpiod2 libhidapi-hidraw0 libtool
  libusb-1.0-0 libusb-1.0-0-dev make pkg-config python3 srecord
- stlink-tools tcl xxd`
-
-OpenOCD can be built as follow:
-
-- `$ git clone https://git.code.sf.net/p/openocd/code openocd`
-- `$ cd openocd`
-- `$ ./bootstrap`
-- `$ ./configure --prefix=/usr --disable-werror --enable-stlink`
-- `$ make`
-- `$ sudo make install`
+ stlink-tools tcl xxd openocd`


### PR DESCRIPTION
So we can remove the note about building it yourself.

I don't use Arch so I've not touched those instructions.