### PR TITLE
Update debugger transport for all boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,84 +1,8 @@
-## Based on github/gitignore templates
-##
-
-# bear
-compile_commands.json
-
-## Vim-specific files
-# swap
-[._]*.s[a-v][a-z]
-[._]*.sw[a-p]
-[._]s[a-v][a-z]
-[._]sw[a-p]
-# session
-Session.vim
-# temporary
-.netrwhist
-*~
-# auto-generated tag files
-tags
-# COC
-.cache/
-
-## C-specific files
-# Prerequisites
-*.d
-
-# Object files
-*.o
-*.ko
-*.obj
-*.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
-
-# Shared objects (inc. Windows DLLs)
-*.dll
-*.so
-*.so.*
-*.dylib
-
-# Executables
-*.exe
-*.out
-*.app
-*.i*86
-*.x86_64
-*.hex
-
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
-
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
-
-
 ## Custom definitions
 # build dirs
 build*/
+.dep/
 **/OD.*
-*.tmp
 
 # Vagrant
 /.vagrant/

--- a/boards/BATTERY_V3/gdboocd.cmd
+++ b/boards/BATTERY_V3/gdboocd.cmd
@@ -1,2 +1,0 @@
-monitor stm32f0x.cpu configure -rtos chibios
-monitor reset halt

--- a/boards/BATTERY_V3/oocd-target.cfg
+++ b/boards/BATTERY_V3/oocd-target.cfg
@@ -1,0 +1,3 @@
+# Set this board's target MCU for openocd
+source [find target/stm32f0x.cfg]
+

--- a/boards/BATTERY_V3/oocd.cfg
+++ b/boards/BATTERY_V3/oocd.cfg
@@ -1,9 +1,0 @@
-#
-#
-# for use with STLINK V2 SWD programmer
-#
-
-source [find interface/stlink.cfg]
-transport select hla_swd
-source [find target/stm32f0x.cfg]
-

--- a/boards/BOARD_TEMPLATE_F0/gdboocd.cmd
+++ b/boards/BOARD_TEMPLATE_F0/gdboocd.cmd
@@ -1,2 +1,0 @@
-monitor stm32f0x.cpu configure -rtos chibios
-monitor reset halt

--- a/boards/BOARD_TEMPLATE_F0/oocd-target.cfg
+++ b/boards/BOARD_TEMPLATE_F0/oocd-target.cfg
@@ -1,0 +1,3 @@
+# Set this board's target MCU for openocd
+source [find target/stm32f0x.cfg]
+

--- a/boards/BOARD_TEMPLATE_F0/oocd.cfg
+++ b/boards/BOARD_TEMPLATE_F0/oocd.cfg
@@ -1,9 +1,0 @@
-#
-#
-# for use with STLINK V2 SWD programmer
-#
-
-source [find interface/stlink.cfg]
-transport select hla_swd
-source [find target/stm32f0x.cfg]
-

--- a/boards/ORESAT_ADCS_V1_2/oocd-target.cfg
+++ b/boards/ORESAT_ADCS_V1_2/oocd-target.cfg
@@ -1,0 +1,3 @@
+# Set this board's target MCU for openocd
+source [find target/stm32f0x.cfg]
+

--- a/boards/ORESAT_ADCS_V1_2/oocd.cfg
+++ b/boards/ORESAT_ADCS_V1_2/oocd.cfg
@@ -1,9 +1,0 @@
-#
-#
-# for use with STLINK V2 SWD programmer
-#
-
-source [find interface/stlink.cfg]
-transport select hla_swd
-source [find target/stm32f0x.cfg]
-

--- a/boards/PROTOCARD_V4/gdboocd.cmd
+++ b/boards/PROTOCARD_V4/gdboocd.cmd
@@ -1,2 +1,0 @@
-monitor stm32f0x.cpu configure -rtos chibios
-monitor reset halt

--- a/boards/PROTOCARD_V4/oocd-target.cfg
+++ b/boards/PROTOCARD_V4/oocd-target.cfg
@@ -1,0 +1,3 @@
+# Set this board's target MCU for openocd
+source [find target/stm32f0x.cfg]
+

--- a/boards/PROTOCARD_V4/oocd.cfg
+++ b/boards/PROTOCARD_V4/oocd.cfg
@@ -1,9 +1,0 @@
-#
-#
-# for use with STLINK V2 SWD programmer
-#
-
-source [find interface/stlink.cfg]
-transport select hla_swd
-source [find target/stm32f0x.cfg]
-

--- a/boards/SOLAR_V5/oocd-target.cfg
+++ b/boards/SOLAR_V5/oocd-target.cfg
@@ -1,0 +1,3 @@
+# Set this board's target MCU for openocd
+source [find target/stm32f0x.cfg]
+

--- a/boards/SOLAR_V5/oocd.cfg
+++ b/boards/SOLAR_V5/oocd.cfg
@@ -1,9 +1,0 @@
-#
-#
-# for use with STLINK V2 SWD programmer
-#
-
-source [find interface/stlink.cfg]
-transport select hla_swd
-source [find target/stm32f0x.cfg]
-

--- a/boards/ST_NUCLEO64_F091RC/gdboocd.cmd
+++ b/boards/ST_NUCLEO64_F091RC/gdboocd.cmd
@@ -1,2 +1,0 @@
-monitor stm32f0x.cpu configure -rtos chibios
-monitor reset halt

--- a/boards/ST_NUCLEO64_F091RC/oocd-target.cfg
+++ b/boards/ST_NUCLEO64_F091RC/oocd-target.cfg
@@ -1,0 +1,2 @@
+# Set this board's target MCU for openocd
+source [find target/stm32f0x.cfg]

--- a/boards/ST_NUCLEO64_F091RC/oocd.cfg
+++ b/boards/ST_NUCLEO64_F091RC/oocd.cfg
@@ -1,9 +1,0 @@
-#
-#
-# for use with STLINK V2 SWD programmer
-#
-
-source [find interface/stlink.cfg]
-transport select dapdirect_swd
-source [find target/stm32f0x.cfg]
-

--- a/toolchain/gdboocd.cmd
+++ b/toolchain/gdboocd.cmd
@@ -1,0 +1,2 @@
+monitor reset init
+monitor $_TARGETNAME configure -rtos chibios

--- a/toolchain/oocd-interface.cfg
+++ b/toolchain/oocd-interface.cfg
@@ -1,0 +1,2 @@
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd


### PR DESCRIPTION
Follwing from 98174ea5f23eb8c this updates all the boards' transports to dapdirect_swd. My rather oldish version of openocd doesn't complain but newer versions have depricated hla_swd on newer stlinks.