### PR TITLE
Refactoring the MAX17205 driver and battery app

### DIFF
--- a/common/include/max17205.h
+++ b/common/include/max17205.h
@@ -1063,9 +1063,6 @@ void max17205ObjectInit(MAX17205Driver *devp);
 bool max17205Start(MAX17205Driver *devp, const MAX17205Config *config);
 void max17205Stop(MAX17205Driver *devp);
 
-msg_t max17205Read(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
-msg_t max17205Write(MAX17205Driver *devp, uint16_t reg, uint16_t value);
-
 /* Reference datasheet table 1 */
 msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest_mA);
 msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_pct);
@@ -1077,12 +1074,13 @@ msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint32_t *dest_S);
 
 msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest_C);
 msg_t max17205ReadBatt(MAX17205Driver *devp, uint16_t *dest_mV);
+msg_t max17205ReadCycles(MAX17205Driver *devp, uint16_t *dest_count);
 msg_t max17205ReadMaxMinVoltage(MAX17205Driver *devp, uint16_t * max_mV, uint16_t * min_mV);
 msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int16_t * max_mV, int16_t * min_mV);
 msg_t max17205ReadMaxMinTemperature(MAX17205Driver *devp, int8_t * max_C, int8_t * min_C);
 
-msg_t max17205HardwareReset(MAX17205Driver *devp);
-
+msg_t max17205ValidateRegisters(MAX17205Driver *devp, const max17205_regval_t * list, size_t len, bool * valid);
+msg_t max17205WriteRegisters(MAX17205Driver *devp, const max17205_regval_t * list, size_t len);
 msg_t max17205ReadNVWriteCountMaskingRegister(MAX17205Driver *devp, uint16_t *reg_dest, uint8_t *number_of_writes_left);
 msg_t max17205NonvolatileBlockProgram(MAX17205Driver *devp);
 msg_t max17205PrintintNonvolatileMemory(MAX17205Driver *devp);

--- a/common/include/max17205.h
+++ b/common/include/max17205.h
@@ -1059,26 +1059,29 @@ struct MAX17205Driver {
 #ifdef __cplusplus
 extern "C" {
 #endif
+/* Driver state machine */
 void max17205ObjectInit(MAX17205Driver *devp);
 bool max17205Start(MAX17205Driver *devp, const MAX17205Config *config);
 void max17205Stop(MAX17205Driver *devp);
 
-/* Reference datasheet table 1 */
-msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest_mA);
-msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_pct);
+/* Reference datasheet table 1, generic register reads */
+msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint32_t *dest_mAh);
+msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint8_t *dest_pct);
 msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_mV);
-msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest_mA);
-msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest_mC);
+msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int32_t *dest_mA);
+msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int32_t *dest_mC);
 msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_mOhm);
 msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint32_t *dest_S);
 
+/* Register reads that require a specific conversion not covered by table 1 */
 msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest_C);
-msg_t max17205ReadBatt(MAX17205Driver *devp, uint16_t *dest_mV);
+msg_t max17205ReadBatt(MAX17205Driver *devp, uint32_t *dest_mV);
 msg_t max17205ReadCycles(MAX17205Driver *devp, uint16_t *dest_count);
 msg_t max17205ReadMaxMinVoltage(MAX17205Driver *devp, uint16_t * max_mV, uint16_t * min_mV);
-msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int16_t * max_mV, int16_t * min_mV);
+msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int32_t * max_mA, int32_t * min_mA);
 msg_t max17205ReadMaxMinTemperature(MAX17205Driver *devp, int8_t * max_C, int8_t * min_C);
 
+/* Misc */
 msg_t max17205ValidateRegisters(MAX17205Driver *devp, const max17205_regval_t * list, size_t len, bool * valid);
 msg_t max17205WriteRegisters(MAX17205Driver *devp, const max17205_regval_t * list, size_t len);
 msg_t max17205ReadNVWriteCountMaskingRegister(MAX17205Driver *devp, uint16_t *reg_dest, uint8_t *number_of_writes_left);

--- a/common/include/max17205.h
+++ b/common/include/max17205.h
@@ -1067,20 +1067,19 @@ msg_t max17205Read(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
 msg_t max17205Write(MAX17205Driver *devp, uint16_t reg, uint16_t value);
 
 /* Reference datasheet table 1 */
-msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest);
-msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
-msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
-msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
-msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
-msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
-msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
+msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest_mA);
+msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_pct);
+msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_mV);
+msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest_mA);
+msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest_mC);
+msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest_mOhm);
+msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint32_t *dest_S);
 
-
-msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
-msg_t max17205ReadBattVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
-msg_t max17205ReadMaxMinVoltage(MAX17205Driver *devp, uint8_t * max, uint8_t * min);
-msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int16_t * max, int16_t * min);
-msg_t max17205ReadMaxMinTemperature(MAX17205Driver *devp, int8_t * max, int8_t * min);
+msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest_C);
+msg_t max17205ReadBatt(MAX17205Driver *devp, uint16_t *dest_mV);
+msg_t max17205ReadMaxMinVoltage(MAX17205Driver *devp, uint16_t * max_mV, uint16_t * min_mV);
+msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int16_t * max_mV, int16_t * min_mV);
+msg_t max17205ReadMaxMinTemperature(MAX17205Driver *devp, int8_t * max_C, int8_t * min_C);
 
 msg_t max17205HardwareReset(MAX17205Driver *devp);
 

--- a/common/include/max17205.h
+++ b/common/include/max17205.h
@@ -1,60 +1,10 @@
-/**
- * @file    max17205.h
- * @brief   MAX17205 Power Monitor.
- *
- * @addtogroup MAX17205
- * @ingroup ORESAT
- * @{
- */
+/*  MAX17205 Power Monitor  */
 #ifndef _MAX17205_H_
 #define _MAX17205_H_
-
-/*===========================================================================*/
-/* Driver constants.                                                         */
-/*===========================================================================*/
-
-/**
- * @name    Version Identification
- * @{
- */
-/**
- * @brief   MAX17205 Driver version string.
- */
-#define MAX17205_VERSION                    "1.0.0"
-
-/**
- * @brief   MAX17205 Driver version major number.
- */
-#define MAX17205_MAJOR                      1
-
-/**
- * @brief   MAX17205 Driver version minor number.
- */
-#define MAX17205_MINOR                      0
-
-/**
- * @brief   MAX17205 Driver version patch number.
- */
-#define MAX17205_PATCH                      0
-/** @} */
-
-/**
- * @brief   MAX17205 Slave Addresses and Conversion
- */
-#define MAX17205_SA_MG                      0x6CU
-#define MAX17205_SA_SBS_NV                  0x16U
-#define MAX17205_SA(reg)                    ((reg & 0x100U ? MAX17205_SA_SBS_NV : MAX17205_SA_MG) >> 1)
-
 
 #define MAX17205_T_RECAL_MS      5
 //tBlock(max) is specified as 7360ms in the data sheet, page 16
 #define MAX17205_T_BLOCK_MS      8000
-
-
-/**
- * @brief   MAX17205 Register Address Conversion
- */
-#define MAX17205_AD(reg)                    (reg & 0xFFU)
 
 /**
  * @name    MAX17205 Register Addresses
@@ -1027,54 +977,14 @@
 #define MAX17205_NRFASTVSHDN_NRFAST         MAX17205_NRFASTVSHDN_NRFAST_Msk
 /** @} */
 
-/*===========================================================================*/
-/* Driver pre-compile time settings.                                         */
-/*===========================================================================*/
-
-/**
- * @name    Configuration options
- * @{
- */
-/**
- * @brief   MAX17205 I2C interface switch.
- * @details If set to @p TRUE the support for I2C is included.
- * @note    The default is @p TRUE.
- */
-#if !defined(MAX17205_USE_I2C) || defined(__DOXYGEN__)
-#define MAX17205_USE_I2C                    TRUE
+#if !HAL_USE_I2C
+#error "MAX17205 requires HAL_USE_I2C"
 #endif
 
-/**
- * @brief   MAX17205 shared I2C switch.
- * @details If set to @p TRUE the device acquires I2C bus ownership
- *          on each transaction.
- * @note    The default is @p FALSE. Requires I2C_USE_MUTUAL_EXCLUSION.
- */
-#if !defined(MAX17205_SHARED_I2C) || defined(__DOXYGEN__)
-#define MAX17205_SHARED_I2C                 FALSE
-#endif
-/** @} */
-
-/*===========================================================================*/
-/* Derived constants and error checks.                                       */
-/*===========================================================================*/
-
-#if MAX17205_USE_I2C && !HAL_USE_I2C
-#error "MAX17205_USE_I2C requires HAL_USE_I2C"
+#if !I2C_USE_MUTUAL_EXCLUSION
+#error "MAX17205 requires I2C_USE_MUTUAL_EXCLUSION"
 #endif
 
-#if MAX17205_SHARED_I2C && !I2C_USE_MUTUAL_EXCLUSION
-#error "MAX17205_SHARED_I2C requires I2C_USE_MUTUAL_EXCLUSION"
-#endif
-
-/*===========================================================================*/
-/* Driver data structures and types.                                         */
-/*===========================================================================*/
-
-/**
- * @name    MAX17205 data structures and types.
- * @{
- */
 /**
  * @brief Structure representing a MAX17205 driver.
  */
@@ -1101,59 +1011,32 @@ typedef struct {
  * @brief   MAX17205 configuration structure.
  */
 typedef struct {
-#if (MAX17205_USE_I2C) || defined(__DOXYGEN__)
     /**
      * @brief I2C driver associated with this MAX17205.
      */
     I2CDriver                   *i2cp;
     /**
-     * @brief I2C configuration associated with this MAX17205.
-     */
-    const I2CConfig             *i2ccfg;
-#endif /* MAX17205_USE_I2C */
-    /**
      * @brief Array of reg:value pairs used to configure the IC.
      */
     const max17205_regval_t     *regcfg;
+    /**
+     * @brief The value of the physical RSENSE resistor in microohms.
+     */
+    uint16_t rsense_uOhm;
 } MAX17205Config;
-
-/**
- * @brief   @p MAX17205 specific methods.
- */
-#define _max17205_methods_alone
-
-/**
- * @brief   @p MAX17205 specific methods with inherited ones.
- */
-#define _max17205_methods                                                   \
-    _base_object_methods
-
-/**
- * @extends BaseObjectVMT
- *
- * @brief   @p MAX17205 virtual methods table.
- */
-struct MAX17205VMT {
-    _max17205_methods
-};
-
-/**
- * @brief   @p MAX17205Driver specific data.
- */
-#define _max17205_data                                                      \
-    _base_object_data                                                       \
-    /* Driver state.*/                                                      \
-    max17205_state_t              state;                                    \
-    /* Current configuration data.*/                                        \
-    const MAX17205Config          *config;
 
 /**
  * @brief MAX17205 Power Monitor class.
  */
 struct MAX17205Driver {
-    /** @brief Virtual Methods Table.*/
-    const struct MAX17205VMT     *vmt;
-    _max17205_data
+    /* Current configuration data. */
+    const MAX17205Config          *config;
+
+    /* Driver state. */
+    max17205_state_t state;
+
+    /* Runtime value of RSENSE. If not set in config it's read from nRSense */
+    uint16_t rsense_uOhm;
 };
 
 /** @} */
@@ -1180,26 +1063,30 @@ void max17205ObjectInit(MAX17205Driver *devp);
 bool max17205Start(MAX17205Driver *devp, const MAX17205Config *config);
 void max17205Stop(MAX17205Driver *devp);
 
-msg_t max17205ReadRaw(MAX17205Driver *devp, uint16_t reg, uint16_t *output_dest);
-msg_t max17205WriteRaw(MAX17205Driver *devp, uint16_t reg, uint16_t value);
+msg_t max17205Read(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
+msg_t max17205Write(MAX17205Driver *devp, uint16_t reg, uint16_t value);
 
+/* Reference datasheet table 1 */
 msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest);
 msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
 msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
-msg_t max17205ReadBattVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
 msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
 msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
-msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
 msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
 msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
 
-msg_t max17205HardwareReset(I2CDriver *i2cp);
-msg_t max17205I2CWriteRegister(I2CDriver *i2cp, i2caddr_t sad, uint8_t *txbuf, size_t n);
-msg_t max17205I2CReadRegister(I2CDriver *i2cp, i2caddr_t sad, uint8_t reg, uint8_t* rxbuf, size_t n);
 
-msg_t max17205ReadNVWriteCountMaskingRegister(const MAX17205Config *config, uint16_t *reg_dest, uint8_t *number_of_writes_left);
-msg_t max17205NonvolatileBlockProgram(const MAX17205Config *config);
-msg_t max17205PrintintNonvolatileMemory(const MAX17205Config *config);
+msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest);
+msg_t max17205ReadBattVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest);
+msg_t max17205ReadMaxMinVoltage(MAX17205Driver *devp, uint8_t * max, uint8_t * min);
+msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int16_t * max, int16_t * min);
+msg_t max17205ReadMaxMinTemperature(MAX17205Driver *devp, int8_t * max, int8_t * min);
+
+msg_t max17205HardwareReset(MAX17205Driver *devp);
+
+msg_t max17205ReadNVWriteCountMaskingRegister(MAX17205Driver *devp, uint16_t *reg_dest, uint8_t *number_of_writes_left);
+msg_t max17205NonvolatileBlockProgram(MAX17205Driver *devp);
+msg_t max17205PrintintNonvolatileMemory(MAX17205Driver *devp);
 
 const char* max17205RegToStr(const uint16_t reg);
 

--- a/common/max17205.c
+++ b/common/max17205.c
@@ -1,322 +1,30 @@
-/**
- * @file    max17205.c
- * @brief   MAX17205 Digital to Analog Converter.
- *
- * @addtogroup MAX17205
- * @ingrup ORESAT
- * @{
- */
+/* @brief   MAX17205 Digital to Analog Converter. */
 
 #include "hal.h"
 #include "max17205.h"
 
-#if 0
+#ifdef DEBUG_PRINT
 #include "chprintf.h"
-#define dbgprintf(str, ...)       chprintf((BaseSequentialStream*) &SD2, str, ##__VA_ARGS__)
+#define DEBUG_SD ((BaseSequentialStream *) &SD2)
+#define dbgprintf(str, ...) chprintf(DEBUG_SD, str, ##__VA_ARGS__)
 #else
 #define dbgprintf(str, ...)
 #endif
 
-/*===========================================================================*/
-/* Driver local definitions.                                                 */
-/*===========================================================================*/
+#define ARRAYSIZE(x) (sizeof(x)/sizeof(x[0]))
 
-/*===========================================================================*/
-/* Driver exported variables.                                                */
-/*===========================================================================*/
-
-/*===========================================================================*/
-/* Driver local variables and types.                                         */
-/*===========================================================================*/
-typedef union {
-    struct __attribute__((packed)) {
-        uint8_t reg;
-        union {
-            uint8_t data[2];
-            uint16_t value;
-        };
-    };
-    uint8_t buf[3];
-} i2cbuf_t;
-
-/*===========================================================================*/
-/* Driver local functions.                                                   */
-/*===========================================================================*/
-
-#if (MAX17205_USE_I2C) || defined(__DOXYGEN__)
-
-/**
- * See page 85 of the data sheet
+/* See datasheet table 27 and figure 74. The chip has 0x1FF registers but the
+ * protocol only allows one byte for register addressing (i.e. registers up to
+ * 0x0FF). To get around this the chip responds two separate I2C slave
+ * addresses, 0x6C for registers 0x00-0xFF and 0x16 for registers 0x100 -
+ * 0x1FF. But wait! Unlike every other datasheet that presents the I2C slave
+ * address as a 7 bit value and assumes your I2C driver will right shift and
+ * set the read/write lsb, this presents the slave addresses as the 8 bit
+ * addresss with read bit set, so we have to unshift them to present it in the
+ * format that ChibiOS' driver expects.
  */
-msg_t max17205NonvolatileBlockProgram(const MAX17205Config *config) {
-	i2cbuf_t buf;
-	msg_t r;
-
-	//	1. Write desired memory locations to new values.
-	//should be done prior to calling this function
-
-	dbgprintf("Clearing CommStat.NVError bit\r\n");
-	//	2. Clear CommStat.NVError bit.
-	buf.reg = MAX17205_AD(MAX17205_AD_COMMSTAT);
-	buf.value = MAX17205_COMMSTAT_NVERROR;
-	if( (r = max17205I2CWriteRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMSTAT), buf.buf, sizeof(buf.buf))) != MSG_OK ) {
-		return(r);
-	}
-
-	//	3. Write 0xE904 to the Command register 0x060 to initiate a block copy.
-	buf.reg = MAX17205_AD(MAX17205_AD_COMMAND);
-	buf.value = 0xE904;
-	if( (r = max17205I2CWriteRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), buf.buf, sizeof(buf.buf))) != MSG_OK ) {
-		dbgprintf("Initiated failed to send command to initiate block copy....\r\n");
-		return(r);
-	} else {
-		dbgprintf("Initiated MAX17205 block copy....\r\n");
-	}
-
-
-	//	4. Wait t BLOCK for the copy to complete.
-
-	dbgprintf("Waiting %u ms for block copy to complete....\r\n", MAX17205_T_BLOCK_MS);
-	chThdSleepMilliseconds(MAX17205_T_BLOCK_MS); //tBlock(max) is specified as 7360ms in the data sheet, page 16
-
-
-	bool successful_block_copy_flag = false;
-	//	5. Check the CommStat.NVError bit. If set, repeat the process. If clear, continue.
-	if( (r = max17205I2CReadRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), MAX17205_AD(MAX17205_AD_COMMSTAT), buf.data, sizeof(buf.data))) != MSG_OK ) {
-		dbgprintf("Failed to query COMMSTAT register...\r\n");
-		return(r);
-	} else {
-		dbgprintf("Read MAX17205_AD_COMMSTAT register 0x%X as 0x%X\r\n", MAX17205_AD_COMMSTAT, buf.value);
-		if( buf.value & MAX17205_COMMSTAT_NVERROR ) {
-			//Error bit is set
-			dbgprintf("Block copy failed...\r\n");
-		} else {
-			dbgprintf("Block copy was successful, breaking...\r\n");
-			successful_block_copy_flag = true;
-		}
-	}
-
-	if( ! successful_block_copy_flag ) {
-		return(MSG_RESET);
-	}
-
-
-	//	6. Write 0x000F to the Command register 0x060 to POR the IC.
-	//	7. Wait t POR for the IC to reset.
-	//	8. Write 0x0001 to Counter Register 0x0BB to reset firmware.
-	//	9. Wait t POR for the firmware to restart.
-	if( (r = max17205HardwareReset(config->i2cp)) != MSG_OK ) {
-		dbgprintf("Failed to reset MAX17205\r\n");
-		return(r);
-	}
-
-	return(MSG_OK);
-}
-
-
-
-/**
- * @brief   Reads registers value using I2C.
- * @pre     The I2C interface must be initialized and the driver started.
- *
- * @param[in]  i2cp      pointer to the I2C interface
- * @param[in]  sad       slave address without R bit
- * @param[in]  reg       first sub-register address
- * @param[out] rxbuf     pointer to an output buffer
- * @param[in]  n         number of consecutive register to read
- * @return               the operation status.
- * @notapi
- */
-msg_t max17205I2CReadRegister(I2CDriver *i2cp, i2caddr_t sad, uint8_t reg,
-        uint8_t* rxbuf, size_t n) {
-    return i2cMasterTransmitTimeout(i2cp, sad, &reg, 1, rxbuf, n,
-            TIME_MS2I(50));
-}
-
-/**
- * @brief   Writes a value into a register using I2C.
- * @pre     The I2C interface must be initialized and the driver started.
- *
- * @param[in] i2cp       pointer to the I2C interface
- * @param[in] sad        slave address without R bit
- * @param[in] txbuf      buffer containing command in first byte and high
- *                       and low data bytes
- * @param[in] n          size of txbuf
- * @return               the operation status.
- * @notapi
- */
-msg_t max17205I2CWriteRegister(I2CDriver *i2cp, i2caddr_t sad, uint8_t *txbuf,
-        size_t n) {
-    return i2cMasterTransmitTimeout(i2cp, sad, txbuf, n, NULL, 0,
-    		TIME_MS2I(50));
-}
-#endif /* MAX17205_USE_I2C */
-
-/*==========================================================================*/
-/* Interface implementation.                                                */
-/*==========================================================================*/
-
-static const struct MAX17205VMT vmt_device = {
-    (size_t)0,
-};
-
-/*===========================================================================*/
-/* Driver exported functions.                                                */
-/*===========================================================================*/
-
-/**
- * @brief   Initializes an instance.
- *
- * @param[out] devp     pointer to the @p MAX17205Driver object
- *
- * @init
- */
-void max17205ObjectInit(MAX17205Driver *devp) {
-    devp->vmt = &vmt_device;
-
-    devp->config = NULL;
-
-    devp->state = MAX17205_STOP;
-}
-
-msg_t max17205HardwareReset(I2CDriver *i2cp) {
-	i2cbuf_t buf;
-	msg_t r;
-
-	dbgprintf("Reseting MAX17205...\r\n");
-
-	buf.reg = MAX17205_AD(MAX17205_AD_COMMAND);
-	buf.value = MAX17205_COMMAND_HARDWARE_RESET;
-	if( (r = max17205I2CWriteRegister(i2cp, MAX17205_SA(MAX17205_AD_COMMAND), buf.buf, sizeof(buf))) != MSG_OK ) {
-		dbgprintf("Cmd register write failed...\r\n");
-		//return(r);
-	}
-	chThdSleepMilliseconds(10);
-
-	uint32_t check_count = 0;
-	do {
-		if( max17205I2CReadRegister(i2cp, MAX17205_SA(MAX17205_AD_COMMAND), MAX17205_AD(MAX17205_AD_STATUS), buf.data, sizeof(buf.data)) != MSG_OK ) {
-			//do nothing
-			dbgprintf("Waiting for MAX17205 to complete reset...\r\n");
-			chThdSleepMilliseconds(10);
-		}
-		check_count++;
-	} while (!(buf.value & MAX17205_STATUS_POR) && check_count < 10); /* While still resetting */
-
-	//FIXME doesn't handle failure to POR properly
-	return(MSG_OK);
-}
-
-/**
- * @brief   Configures and activates MAX17205 Complex Driver peripheral.
- *
- * @param[in] devp      pointer to the @p MAX17205Driver object
- * @param[in] config    pointer to the @p MAX17205Config object
- *
- * @api
- */
-bool max17205Start(MAX17205Driver *devp, const MAX17205Config *config) {
-    i2cbuf_t buf;
-    uint32_t comm_error_count = 0;
-
-    osalDbgCheck((devp != NULL) && (config != NULL));
-    osalDbgAssert((devp->state == MAX17205_STOP) ||
-            (devp->state == MAX17205_READY),
-            "max17205Start(), invalid state");
-
-    devp->config = config;
-
-    /* Configuring common registers.*/
-#if MAX17205_USE_I2C
-#if MAX17205_SHARED_I2C
-    i2cAcquireBus(config->i2cp);
-#endif /* MAX17205_SHARED_I2C */
-
-    i2cStart(config->i2cp, config->i2ccfg);
-
-    /* Reset device */
-#if 0
-    max17205HardwareReset(config->i2cp);
-#endif
-
-
-#if 0
-    //Read npkgcfg         0xA02
-    if( max17205I2CReadRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), MAX17205_AD(MAX17205_AD_PACKCFG), buf.data, sizeof(buf.data)) == MSG_OK ) {
-		dbgprintf("Read MAX17205_AD_PACKCFG register 0x%X as 0x%X\r\n", MAX17205_AD_PACKCFG, buf.value);
-	}
-#endif
-
-
-
-    buf.reg = MAX17205_AD(MAX17205_AD_CONFIG2);
-    buf.value = MAX17205_SETVAL(MAX17205_AD_CONFIG2, MAX17205_CONFIG2_POR_CMD);
-    if( max17205I2CWriteRegister(config->i2cp, MAX17205_SA(MAX17205_AD_CONFIG2), buf.buf, sizeof(buf)) != MSG_OK ) {
-    	comm_error_count++;
-    }
-
-    for (const max17205_regval_t *pair = config->regcfg; pair->reg; pair++) {
-        buf.reg = MAX17205_AD(pair->reg);
-        buf.value = pair->value;
-
-        dbgprintf("Setting MAX17205 register 0x%X to 0x%X\r\n", buf.reg, buf.value);
-
-        if( max17205I2CWriteRegister(config->i2cp, MAX17205_SA(pair->reg), buf.buf, sizeof(buf)) != MSG_OK ) {
-        	comm_error_count++;
-        }
-    }
-
-#if MAX17205_SHARED_I2C
-    i2cReleaseBus(config->i2cp);
-#endif /* MAX17205_SHARED_I2C */
-#endif /* MAX17205_USE_I2C */
-
-    if( comm_error_count == 0 ) {
-    	devp->state = MAX17205_READY;
-    	return(true);
-    } else {
-    	devp->state = MAX17205_UNINIT;
-    }
-    return(false);
-}
-
-/**
- * @brief   Deactivates the MAX17205 Complex Driver peripheral.
- *
- * @param[in] devp       pointer to the @p MAX17205Driver object
- *
- * @api
- */
-void max17205Stop(MAX17205Driver *devp) {
-    i2cbuf_t buf;
-
-    osalDbgCheck(devp != NULL);
-    osalDbgAssert((devp->state == MAX17205_STOP) || (devp->state == MAX17205_READY),
-            "max17205Stop(), invalid state");
-
-    if (devp->state == MAX17205_READY) {
-#if MAX17205_USE_I2C
-#if MAX17205_SHARED_I2C
-        i2cAcquireBus(devp->config->i2cp);
-        i2cStart(devp->config->i2cp, devp->config->i2ccfg);
-#endif /* MAX17205_SHARED_I2C */
-
-        /* Reset device */
-        buf.reg = MAX17205_AD(MAX17205_AD_COMMAND);
-        buf.value = MAX17205_COMMAND_HARDWARE_RESET;
-        max17205I2CWriteRegister(devp->config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), buf.buf, sizeof(buf));
-        buf.reg = MAX17205_AD(MAX17205_AD_CONFIG2);
-        buf.value = MAX17205_SETVAL(MAX17205_AD_CONFIG2, MAX17205_CONFIG2_POR_CMD);
-        max17205I2CWriteRegister(devp->config->i2cp, MAX17205_SA(MAX17205_AD_CONFIG2), buf.buf, sizeof(buf));
-
-        i2cStop(devp->config->i2cp);
-#if MAX17205_SHARED_I2C
-        i2cReleaseBus(devp->config->i2cp);
-#endif /* MAX17205_SHARED_I2C */
-#endif /* MAX17205_USE_I2C */
-    }
-    devp->state = MAX17205_STOP;
-}
+#define I2C_ADDR(reg) ((reg > 0xFFU) ? (0x16U >> 1) : (0x6CU >> 1))
+#define MEM_ADDR(reg) (reg & 0xFFU)
 
 /**
  * @brief   Reads MAX17205 register as raw value.
@@ -326,37 +34,23 @@ void max17205Stop(MAX17205Driver *devp) {
  *
  * @api
  */
-msg_t max17205ReadRaw(MAX17205Driver *devp, uint16_t reg, uint16_t *output_dest) {
-    i2cbuf_t buf;
-
+msg_t max17205Read(MAX17205Driver *devp, uint16_t reg, uint16_t *dest) {
     osalDbgCheck(devp != NULL);
     osalDbgAssert(devp->state == MAX17205_READY,
             "max17205ReadRaw(), invalid state");
 
-#if MAX17205_USE_I2C
-#if MAX17205_SHARED_I2C
+    uint8_t mem = MEM_ADDR(reg);
+    uint8_t buf[2] = {};
+
     i2cAcquireBus(devp->config->i2cp);
-    i2cStart(devp->config->i2cp, devp->config->i2ccfg);
-#endif /* MAX17205_SHARED_I2C */
-
-    buf.reg = MAX17205_AD(reg);
-
-    const msg_t r = max17205I2CReadRegister(devp->config->i2cp, MAX17205_SA(reg), buf.reg, buf.data, sizeof(buf.data));
-
-    //dbgprintf("max17205I2CReadRegister(0x%X), r = %d", reg, r);
-
-#if MAX17205_SHARED_I2C
+    const msg_t r = i2cMasterTransmitTimeout(devp->config->i2cp, I2C_ADDR(reg), &mem, sizeof(mem), buf, sizeof(buf), TIME_MS2I(50));
     i2cReleaseBus(devp->config->i2cp);
-#endif /* MAX17205_SHARED_I2C */
-#endif /* MAX17205_USE_I2C */
 
-    if( r == MSG_OK ) {
-    	*output_dest = buf.value;
-    	//dbgprintf(" value = %u 0x%X", buf.value, buf.value);
+    if (r == MSG_OK) {
+        *dest = buf[0] | buf[1] << 8;
     }
-    //dbgprintf("\r\n");
 
-    return(r);
+    return r;
 }
 
 /**
@@ -368,64 +62,161 @@ msg_t max17205ReadRaw(MAX17205Driver *devp, uint16_t reg, uint16_t *output_dest)
  *
  * @api
  */
-msg_t max17205WriteRaw(MAX17205Driver *devp, uint16_t reg, uint16_t value) {
-    i2cbuf_t buf;
-
+msg_t max17205Write(MAX17205Driver *devp, uint16_t reg, uint16_t value) {
     osalDbgCheck(devp != NULL);
     osalDbgAssert(devp->state == MAX17205_READY,
             "max17205WriteRaw(), invalid state");
 
-#if MAX17205_USE_I2C
-#if MAX17205_SHARED_I2C
+    uint8_t buf[3] = {MEM_ADDR(reg), value & 0xFF, (value >> 8) & 0xFF};
+
     i2cAcquireBus(devp->config->i2cp);
-    i2cStart(devp->config->i2cp, devp->config->i2ccfg);
-#endif /* MAX17205_SHARED_I2C */
-
-    buf.reg = MAX17205_AD(reg);
-    buf.value = value;
-    const msg_t r = max17205I2CWriteRegister(devp->config->i2cp, MAX17205_SA(reg), buf.buf, sizeof(buf));
-
-#if MAX17205_SHARED_I2C
+    const msg_t r = i2cMasterTransmitTimeout(devp->config->i2cp, I2C_ADDR(reg), buf, sizeof(buf), NULL, 0, TIME_MS2I(50));
     i2cReleaseBus(devp->config->i2cp);
-#endif /* MAX17205_SHARED_I2C */
-#endif /* MAX17205_USE_I2C */
 
-    return(r);
+    return r;
 }
 
+/**
+ * @brief   Initializes an instance.
+ *
+ * @param[out] devp     pointer to the @p MAX17205Driver object
+ *
+ * @init
+ */
+void max17205ObjectInit(MAX17205Driver *devp) {
+    devp->config = NULL;
+    devp->state = MAX17205_STOP;
+}
+
+msg_t max17205HardwareReset(MAX17205Driver * devp) {
+    msg_t r = max17205Write(devp, MAX17205_AD_COMMAND, MAX17205_COMMAND_HARDWARE_RESET);
+    if (r != MSG_OK) {
+        return r;
+    }
+
+    uint32_t check_count = 0;
+    uint16_t status = 0;
+    do {
+        r = max17205Read(devp, MAX17205_AD_STATUS, &status);
+        if (r != MSG_OK) {
+            return r;
+        }
+        check_count++;
+    } while (!(status & MAX17205_STATUS_POR) && check_count < 10); /* While still resetting */
+
+    if (!(status & MAX17205_STATUS_POR))
+        return MSG_RESET;
+
+    r = max17205Write(devp, MAX17205_AD_CONFIG2, MAX17205_CONFIG2_POR_CMD);
+    if (r != MSG_OK) {
+        return r;
+    }
+
+    check_count = 0;
+    status = 0;
+    do {
+        r = max17205Read(devp, MAX17205_AD_STATUS, &status);
+        if (r != MSG_OK) {
+            return r;
+        }
+        check_count++;
+    } while (!(status & MAX17205_STATUS_POR) && check_count < 10); /* While still resetting */
+
+    if (!(status & MAX17205_STATUS_POR))
+        return MSG_RESET;
+
+    return MSG_OK;
+}
+
+/**
+ * @brief   Configures and activates MAX17205 Complex Driver peripheral.
+ *
+ * @param[in] devp      pointer to the @p MAX17205Driver object
+ * @param[in] config    pointer to the @p MAX17205Config object
+ *
+ * @api
+ */
+bool max17205Start(MAX17205Driver *devp, const MAX17205Config *config) {
+    uint32_t comm_error_count = 0;
+
+    osalDbgCheck((devp != NULL) && (config != NULL));
+    osalDbgAssert((devp->state == MAX17205_STOP) ||
+            (devp->state == MAX17205_READY),
+            "max17205Start(), invalid state");
+
+    devp->state = MAX17205_STOP;
+    devp->config = config;
+
+    if (max17205Write(devp, MAX17205_AD_CONFIG2, MAX17205_CONFIG2_POR_CMD) != MSG_OK) {
+        comm_error_count++;
+    }
+
+    // FIXME: is resetting just config2 correct? We should also wait for POR
+
+    for (const max17205_regval_t *pair = config->regcfg; pair->reg; pair++) {
+        dbgprintf("Setting MAX17205 register 0x%X to 0x%X\r\n", pair->reg, pair->value);
+
+        if (max17205Write(devp, pair->reg, pair->value) != MSG_OK) {
+            comm_error_count++;
+        }
+    }
+
+    devp->rsense_uOhm = config->rsense_uOhm;
+    if (devp->rsense_uOhm == 0) {
+        uint16_t nr_sense_value = 0;
+        if (max17205Read(devp, MAX17205_AD_NRSENSE, &nr_sense_value) != MSG_OK) {
+            ++comm_error_count;
+        }
+        devp->rsense_uOhm = nr_sense_value;
+    }
+
+    if (comm_error_count == 0) {
+        devp->state = MAX17205_READY;
+        return true;
+    } else {
+        devp->state = MAX17205_UNINIT;
+    }
+    return false;
+}
+
+/**
+ * @brief   Deactivates the MAX17205 Complex Driver peripheral.
+ *
+ * @param[in] devp       pointer to the @p MAX17205Driver object
+ *
+ * @api
+ */
+void max17205Stop(MAX17205Driver *devp) {
+    osalDbgCheck(devp != NULL);
+    osalDbgAssert((devp->state == MAX17205_STOP) || (devp->state == MAX17205_READY),
+            "max17205Stop(), invalid state");
+
+    // FIXME: Given how the chip works does "stop" even make sense?
+    if (devp->state == MAX17205_READY) {
+        max17205Write(devp, MAX17205_AD_COMMAND, MAX17205_COMMAND_HARDWARE_RESET);
+        max17205Write(devp, MAX17205_AD_CONFIG2, MAX17205_CONFIG2_POR_CMD);
+    }
+    devp->state = MAX17205_STOP;
+}
 
 /**
  * @brief   Reads an MAX17205 capacity value from a register in mAh.
- * @pre     nRSENSE register must be set to a value with a LSB of 10uOhm
  *
  * @param[in] devp       pointer to the @p MAX17205Driver object
  * @param[in] reg        the register to read from
  *
  * @api
  */
-msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest)
-{
-	uint16_t reg_value = 0;
-	const msg_t r = max17205ReadRaw(devp, reg, &reg_value);
-
-	if( r == MSG_OK ) {
-		uint16_t nr_sense_value = 0;
-
-		const msg_t r2 = max17205ReadRaw(devp, MAX17205_AD_NRSENSE, &nr_sense_value);
-		if( r2 == MSG_OK ) {
-			*dest = reg_value * 5000U / MAX17205_REG2RSENSE(nr_sense_value);
-
-			dbgprintf("  max17205ReadCapacityChecked(0x%X %s) = %u mAh (raw: %u 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, reg_value, reg_value);
-		} else {
-			return(r2);
-		}
-	} else {
-		return(r);
-	}
-
-	return(MSG_OK);
+msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *dest) {
+    uint16_t buf = 0;
+    const msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = buf * 5000 / devp->rsense_uOhm;
+        dbgprintf("  max17205ReadCapacity(0x%X %s) = %u mAh (raw: 0x%X)\r\n",
+            reg, max17205RegToStr(reg), *dest, buf);
+    }
+    return r;
 }
-
 
 /**
  * @brief   Reads an MAX17205 percentage value from a register in 1% increments.
@@ -435,38 +226,15 @@ msg_t max17205ReadCapacity(MAX17205Driver *devp, const uint16_t reg, uint16_t *d
  *
  * @api
  */
-msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
-{
-	uint16_t temp = 0;
-    msg_t r = max17205ReadRaw(devp, reg, &temp);
-
-    if( r == MSG_OK ) {
-    	*dest = temp / 256U;
-    	dbgprintf("  max17205ReadPercentageChecked(0x%X %s) = %u%% (raw: %u 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, temp, temp);
+msg_t max17205ReadPercentage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = buf / 256U;
+        dbgprintf("  max17205ReadPercentageChecked(0x%X %s) = %u%% (raw: 0x%X)\r\n",
+            reg, max17205RegToStr(reg), *dest, buf);
     }
-    return(r);
-}
-
-
-/**
- * @brief   Reads an MAX17205 voltage value from a register in mV.
- *
- * @param[in] devp       pointer to the @p MAX17205Driver object
- * @param[in] reg        the register to read from
- *
- * @api
- */
-msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
-{
-	uint16_t temp = 0;
-	msg_t r = max17205ReadRaw(devp, reg, &temp);
-
-	if( r == MSG_OK ) {
-		//Output is in millivolts. LSB unit is 0.078125mV
-		*dest = (((uint32_t) temp) * 78125U) / 1000000U;
-		dbgprintf("  max17205ReadVoltageChecked(0x%X %s) = %u mV\r\n", reg, max17205RegToStr(reg), *dest);
-	}
-	return(r);
+    return r;
 }
 
 /**
@@ -477,44 +245,77 @@ msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
  *
  * @api
  */
-msg_t max17205ReadBattVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
-{
-	uint16_t temp = 0;
-	msg_t r = max17205ReadRaw(devp, reg, &temp);
-
-	if( r == MSG_OK ) {
-		//Output is in millivolts. LSB unit is 1.25mV
-		*dest = (((uint32_t) temp) * 125U) / 100U;
-		dbgprintf("  max17205ReadBattVoltage(0x%X %s) = %u mV\r\n", reg, max17205RegToStr(reg), *dest);
-	}
-	return(r);
+msg_t max17205ReadVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        //Output is in millivolts. LSB unit is 0.078125mV
+        *dest = (((uint32_t) buf) * 78125U) / 1000000U;
+        dbgprintf("  max17205ReadVoltageChecked(0x%X %s) = %u mV\r\n", reg, max17205RegToStr(reg), *dest);
+    }
+    return r;
 }
 
+/**
+ * @brief   Reads an MAX17205 voltage value from a register in mV.
+ *
+ * @param[in] devp       pointer to the @p MAX17205Driver object
+ * @param[in] reg        the register to read from
+ *
+ * @api
+ */
+msg_t max17205ReadBattVoltage(MAX17205Driver *devp, uint16_t reg, uint16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        //Output is in millivolts. LSB unit is 1.25mV
+        *dest = (((uint32_t) buf) * 125U) / 100U;
+        dbgprintf("  max17205ReadBattVoltage(0x%X %s) = %u mV\r\n", reg, max17205RegToStr(reg), *dest);
+    }
+    return r;
+}
+
+msg_t max17205ReadMaxMinVoltage(MAX17205Driver *devp, uint8_t * max, uint8_t * min) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, MAX17205_AD_MAXMINVOLT, &buf);
+    if (r == MSG_OK) {
+        *max =  (buf >> 8) * 20;
+        *min = (buf & 0xFF) * 20;
+    }
+    return r;
+}
 
 /**
  * @brief   Reads an MAX17205 current value from a register in mA.
- * @pre     nRSENSE register must be set to a value with a LSB of 10uOhm
  *
  * @param[in] devp       pointer to the @p MAX17205Driver object
  * @param[in] reg        the register to read from
  *
  * @api
  */
-msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest)
-{
-	uint16_t temp = 0;
-	msg_t r = max17205ReadRaw(devp, reg, &temp);
-
-	if( r == MSG_OK ) {
-		int16_t temp_signed = temp;
-		//Assumes Rsense = 0.01 ohms
-		*dest = ((int32_t)temp_signed * 15625) / 100000;// 156.25 uA / 100 / 1000 uA/mA
-
-		dbgprintf("  max17205ReadCurrent(0x%X %s) = %d mA (raw: %d 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, temp_signed, temp);
-	}
-	return(r);
+msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = ((int32_t)(int16_t)buf * 15625) / devp->rsense_uOhm;
+        dbgprintf("  max17205ReadCurrent(0x%X %s) = %d mA (raw: 0x%X)\r\n",
+            reg, max17205RegToStr(reg), *dest, buf);
+    }
+    return r;
 }
 
+
+msg_t max17205ReadMaxMinCurrent(MAX17205Driver *devp, int16_t * max, int16_t * min) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, MAX17205_AD_MAXMINCURR, &buf);
+    if (r == MSG_OK) {
+        int8_t max_raw = (buf >> 8);
+        int8_t min_raw = buf & 0xFF;
+        *max = ((int16_t) max_raw) * 40000 / devp->rsense_uOhm;
+        *min = ((int16_t) min_raw) * 40000 / devp->rsense_uOhm;
+    }
+    return r;
+}
 
 /**
  * @brief   Reads an MAX17205 temperature value from a register in 0.001C increments.
@@ -524,17 +325,14 @@ msg_t max17205ReadCurrent(MAX17205Driver *devp, uint16_t reg, int16_t *dest)
  *
  * @api
  */
-msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest)
-{
-	uint16_t temp = 0;
-	msg_t r = max17205ReadRaw(devp, reg, &temp);
-	if( r == MSG_OK ) {
-		int16_t temp_signed = temp;
-
-		*dest = temp_signed * 1000U / 256U;
-		dbgprintf("  max17205ReadTemperatureChecked(0x%X %s) = %d mC (%u C) (raw: %d 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, (*dest / 1000), temp_signed, temp);
-	}
-    return(r);
+msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = (int16_t)buf * 1000U / 256U;
+        dbgprintf("  max17205ReadTemperatureChecked(0x%X %s) = %d mC (%u C) (raw: 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, (*dest / 1000), buf);
+    }
+    return r;
 }
 
 /**
@@ -545,17 +343,24 @@ msg_t max17205ReadTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest)
  *
  * @api
  */
-msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest)
-{
-	uint16_t temp = 0;
-	msg_t r = max17205ReadRaw(devp, reg, &temp);
-	if( r == MSG_OK ) {
-		int16_t temp_signed = temp;
+msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = ((int16_t)buf / 10) - 273;
+        dbgprintf("  max17205ReadTemperatureChecked(0x%X %s) = %d C (raw: 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, buf);
+    }
+    return r;
+}
 
-		*dest = (temp_signed / 10) - 273;
-		dbgprintf("  max17205ReadTemperatureChecked(0x%X %s) = %d C (raw: %d 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, temp_signed, temp);
-	}
-    return(r);
+msg_t max17205ReadMaxMinTemperature(MAX17205Driver *devp, int8_t * max, int8_t * min) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, MAX17205_AD_MAXMINTEMP, &buf);
+    if (r == MSG_OK) {
+        *max = ((int16_t)buf) >> 8;
+        *min = buf & 0xFF;
+    }
+    return r;
 }
 
 /**
@@ -566,22 +371,15 @@ msg_t max17205ReadAverageTemperature(MAX17205Driver *devp, uint16_t reg, int16_t
  *
  * @api
  */
-/*
-inline uint16_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg)
-{
-    return max17205ReadRaw(devp, reg) * 1000U / 4096U;
-}
-*/
 
-msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
-{
-	uint16_t temp;
-	msg_t r = max17205ReadRaw(devp, reg, &temp);
-	if( r == MSG_OK ) {
-		*dest = temp * 1000U / 4096U;
-	}
+msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest) {
+    uint16_t buf;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = buf * 1000U / 4096U;
+    }
 
-	return(r);
+    return r;
 }
 
 /**
@@ -592,17 +390,14 @@ msg_t max17205ReadResistance(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
  *
  * @api
  */
-msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
-{
-	uint16_t temp = 0;
-    msg_t r = max17205ReadRaw(devp, reg, &temp);
-    if( r == MSG_OK ) {
-    	*dest = temp * 5625U / 1000;
-
-    	uint16_t minutes = *dest / 60;
-    	dbgprintf("  max17205ReadTimeChecked(0x%X %s) = %u seconds (%u minutes) (raw: %u 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, minutes, temp, temp);
+msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint16_t *dest) {
+    uint16_t buf = 0;
+    msg_t r = max17205Read(devp, reg, &buf);
+    if (r == MSG_OK) {
+        *dest = buf * 5625U / 1000;
+        dbgprintf("  max17205ReadTimeChecked(0x%X %s) = %u seconds (raw: 0x%X)\r\n", reg, max17205RegToStr(reg), *dest, buf);
     }
-    return(r);
+    return r;
 }
 
 /**
@@ -610,409 +405,458 @@ msg_t max17205ReadTime(MAX17205Driver *devp, uint16_t reg, uint16_t *dest)
  *
  * TODO document this
  */
-msg_t max17205ReadNVWriteCountMaskingRegister(const MAX17205Config *config, uint16_t *reg_dest, uint8_t *number_of_writes_left) {
-	//Determine the number of times NV memory has been written on this chip.
-	//See page 85 of the data sheet
+msg_t max17205ReadNVWriteCountMaskingRegister(MAX17205Driver *devp, uint16_t *reg_dest, uint8_t *number_of_writes_left) {
+    //Determine the number of times NV memory has been written on this chip.
+    //See page 85 of the data sheet
 
-	dbgprintf("Reading NV Masking register...\r\n");
-	i2cbuf_t buf;
+    dbgprintf("Reading NV Masking register...\r\n");
 
-	buf.reg = MAX17205_AD_COMMAND;
-	buf.value = 0xE2FA;
-	if( max17205I2CWriteRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), buf.buf, sizeof(buf.buf)) == MSG_OK ) {
-		chThdSleepMilliseconds(MAX17205_T_RECAL_MS);
+    uint16_t value = 0xE2FA;
+    msg_t r = max17205Write(devp, MAX17205_AD_COMMAND, value);
+    if (r != MSG_OK ) {
+        return r;
+    }
+    chThdSleepMilliseconds(MAX17205_T_RECAL_MS);
 
-		if( max17205I2CReadRegister(config->i2cp, MAX17205_SA(0x1ED), 0xED, buf.data, sizeof(buf.data)) == MSG_OK ) {
-			uint8_t mm = (buf.value & 0xFF) & ((buf.value >> 8) & 0xFF);
-			dbgprintf("Memory Update Masking of register 0x%X is 0x%X\r\n", 0x1ED, mm);
+    uint16_t buf;
+    r = max17205Read(devp, 0x1ED, &buf);
+    if (r != MSG_OK) {
+        return r;
+    }
 
-			uint8_t num_left = 7;
-			for(uint8_t i = 0; i < 8; i++) {
-				if( buf.value & (1<<i) && num_left > 0) {
-					num_left--;
-				}
-			}
+    uint8_t mm = (buf & 0xFF) & ((buf >> 8) & 0xFF);
+    dbgprintf("Memory Update Masking of register 0x%X is 0x%X\r\n", 0x1ED, mm);
 
-			*reg_dest = buf.value;
-			*number_of_writes_left = num_left;
-			return(MSG_OK);
-		}
-	}
+    uint8_t num_left = 7;
+    for(uint8_t i = 0; i < 8; i++) {
+        if (buf & (1<<i) && num_left > 0) {
+            num_left--;
+        }
+    }
 
-	return(MSG_TIMEOUT);
+    *reg_dest = buf;
+    *number_of_writes_left = num_left;
+    return MSG_OK;
 }
 
 /**
- * TODO document this
+ * See page 85 of the data sheet
  */
-msg_t max17205PrintintNonvolatileMemory(const MAX17205Config *config) {
-	i2cbuf_t buf;
+msg_t max17205NonvolatileBlockProgram(MAX17205Driver *devp) {
+    //  1. Write desired memory locations to new values.
+    //should be done prior to calling this function
+
+    dbgprintf("Clearing CommStat.NVError bit\r\n");
+    //  2. Clear CommStat.NVError bit.
+    msg_t r = max17205Write(devp, MAX17205_AD_COMMSTAT, MAX17205_COMMSTAT_NVERROR);
+    if (r != MSG_OK) {
+        return r;
+    }
+
+    //  3. Write 0xE904 to the Command register 0x060 to initiate a block copy.
+    r = max17205Write(devp, MAX17205_AD_COMMAND, 0xE904);
+    if (r != MSG_OK) {
+        dbgprintf("Initiated failed to send command to initiate block copy....\r\n");
+        return r;
+    }
+    dbgprintf("Initiated MAX17205 block copy....\r\n");
+
+    //  4. Wait t BLOCK for the copy to complete.
+    dbgprintf("Waiting %u ms for block copy to complete....\r\n", MAX17205_T_BLOCK_MS);
+    chThdSleepMilliseconds(MAX17205_T_BLOCK_MS); //tBlock(max) is specified as 7360ms in the data sheet, page 16
+
+    uint16_t buf = 0;
+    //  5. Check the CommStat.NVError bit. If set, repeat the process. If clear, continue.
+    r = max17205Read(devp, MAX17205_AD_COMMSTAT, &buf);
+    if (r != MSG_OK) {
+        dbgprintf("Failed to query COMMSTAT register...\r\n");
+        return r;
+    }
+
+    dbgprintf("Read MAX17205_AD_COMMSTAT register 0x%X as 0x%X\r\n", MAX17205_AD_COMMSTAT, buf);
+    if (buf & MAX17205_COMMSTAT_NVERROR) {
+        //Error bit is set
+        dbgprintf("Block copy failed...\r\n");
+        return MSG_RESET;
+    }
+    dbgprintf("Block copy was successful, breaking...\r\n");
 
 
-	uint16_t masking_register = 0;
-	uint8_t num_left = 0;
-	if( max17205ReadNVWriteCountMaskingRegister(config, &masking_register, &num_left) == MSG_OK ) {
+    //  6. Write 0x000F to the Command register 0x060 to POR the IC.
+    //  7. Wait t POR for the IC to reset.
+    //  8. Write 0x0001 to Counter Register 0x0BB to reset firmware.
+    //  9. Wait t POR for the firmware to restart.
+    dbgprintf("Reseting MAX17205...\r\n");
+    if ((r = max17205HardwareReset(devp)) != MSG_OK) {
+        dbgprintf("Failed to reset MAX17205\r\n");
+        return r;
+    }
 
-	}
+    return MSG_OK;
+}
 
+msg_t max17205PrintintNonvolatileMemory(MAX17205Driver *devp) {
+    uint16_t masking_register = 0;
+    uint8_t num_left = 0;
+    msg_t r = max17205ReadNVWriteCountMaskingRegister(devp, &masking_register, &num_left);
+    if (r != MSG_OK) {
+        return r;
+    }
 
-	dbgprintf("\r\nMAX17205 *Volatile* Registers\r\n");
-	uint16_t volatile_reg_list[] = {
-			MAX17205_AD_PACKCFG,
-			MAX17205_AD_DESIGNCAP,
-			MAX17205_AD_NRSENSE,
-			0
-	};
+    dbgprintf("\r\nMAX17205 *Volatile* Registers\r\n");
+    uint16_t volatile_reg_list[] = {
+        MAX17205_AD_PACKCFG,
+        MAX17205_AD_DESIGNCAP,
+        MAX17205_AD_NRSENSE,
+    };
 
-	for(int i = 0; volatile_reg_list[i] != 0;i++) {
-		if( max17205I2CReadRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), MAX17205_AD(volatile_reg_list[i]), buf.data, sizeof(buf.data)) == MSG_OK ) {
-			dbgprintf("   %-30s register 0x%X is 0x%X\r\n", max17205RegToStr(volatile_reg_list[i]), volatile_reg_list[i], buf.value);
-		}
-	}
+    for(size_t i = 0; i < ARRAYSIZE(volatile_reg_list); ++i) {
+        uint16_t buf = 0;
+        r = max17205Read(devp, volatile_reg_list[i], &buf);
+        if (r != MSG_OK) {
+            return r;
+        }
+        dbgprintf("   %-30s register 0x%X is 0x%X\r\n", max17205RegToStr(volatile_reg_list[i]), volatile_reg_list[i], buf);
+    }
 
+    // See table 19 on page 83 of the data sheet to see the list of non-volatile registers
+    dbgprintf("\r\nMAX17205 Non-Volatile Registers\r\n");
+    uint16_t reg_list[] = {
+        MAX17205_AD_NXTABLE0,
+        MAX17205_AD_NXTABLE1,
+        MAX17205_AD_NXTABLE2,
+        MAX17205_AD_NXTABLE3,
+        MAX17205_AD_NXTABLE4,
+        MAX17205_AD_NXTABLE5,
+        MAX17205_AD_NXTABLE6,
+        MAX17205_AD_NXTABLE7,
+        MAX17205_AD_NXTABLE8,
+        MAX17205_AD_NXTABLE9,
+        MAX17205_AD_NXTABLE10,
+        MAX17205_AD_NXTABLE11,
+        MAX17205_AD_NUSER18C,
+        MAX17205_AD_NUSER18D,
+        MAX17205_AD_NODSCTH,
+        MAX17205_AD_NODSCCFG,
+        MAX17205_AD_NOCVTABLE0,
+        MAX17205_AD_NOCVTABLE1,
+        MAX17205_AD_NOCVTABLE2,
+        MAX17205_AD_NOCVTABLE3,
+        MAX17205_AD_NOCVTABLE4,
+        MAX17205_AD_NOCVTABLE5,
+        MAX17205_AD_NOCVTABLE6,
+        MAX17205_AD_NOCVTABLE7,
+        MAX17205_AD_NOCVTABLE8,
+        MAX17205_AD_NOCVTABLE9,
+        MAX17205_AD_NOCVTABLE10,
+        MAX17205_AD_NOCVTABLE11,
+        MAX17205_AD_NICHGTERM,
+        MAX17205_AD_NFILTERCFG,
+        MAX17205_AD_NVEMPTY,
+        MAX17205_AD_NLEARNCFG,
+        MAX17205_AD_NQRTABLE00,
+        MAX17205_AD_NQRTABLE10,
+        MAX17205_AD_NQRTABLE20,
+        MAX17205_AD_NQRTABLE30,
+        MAX17205_AD_NCYCLES,
+        MAX17205_AD_NFULLCAPNOM,
+        MAX17205_AD_NRCOMP0,
+        MAX17205_AD_NTEMPCO,
+        MAX17205_AD_NIAVGEMPTY,
+        MAX17205_AD_NFULLCAPREP,
+        MAX17205_AD_NVOLTTEMP,
+        MAX17205_AD_NMAXMINCURR,
+        MAX17205_AD_NMAXMINVOLT,
+        MAX17205_AD_NMAXMINTEMP,
+        MAX17205_AD_NSOC,
+        MAX17205_AD_NTIMERH,
+        MAX17205_AD_NCONFIG,
+        MAX17205_AD_NRIPPLECFGCFG,
+        MAX17205_AD_NMISCCFG,
+        MAX17205_AD_NDESIGNCAP,
+        MAX17205_AD_NHIBCFG,
+        MAX17205_AD_NPACKCFG,
+        MAX17205_AD_NRELAXCFG,
+        MAX17205_AD_NCONVGCFG,
+        MAX17205_AD_NNVCFG0,
+        MAX17205_AD_NNVCFG1,
+        MAX17205_AD_NNVCFG2,
+        MAX17205_AD_NVALRTTH,
+        MAX17205_AD_NTALRTTH,
+        MAX17205_AD_NSALRTTH,
+        MAX17205_AD_NIALRTTH,
+        MAX17205_AD_NFULLSOCTHR,
+        MAX17205_AD_NTTFCFG,
+        MAX17205_AD_NCGAIN,
+        MAX17205_AD_NTCURVE,
+        MAX17205_AD_NTGAIN,
+        MAX17205_AD_NTOFF,
+        MAX17205_AD_NMANFCTRNAME0,
+        MAX17205_AD_NMANFCTRNAME1,
+        MAX17205_AD_NMANFCTRNAME2,
+        MAX17205_AD_NRSENSE,
+        MAX17205_AD_NUSER1D0,
+        MAX17205_AD_NUSER1D1,
+        MAX17205_AD_NAGEFCCFG,
+        MAX17205_AD_NDESIGNVOLTAGE,
+        MAX17205_AD_NUSER1D4,
+        MAX17205_AD_NRFASTVSHDN,
+        MAX17205_AD_NMANFCTRDATE,
+        MAX17205_AD_NFIRSTUSED,
+        MAX17205_AD_NSERIALNUMBER0,
+        MAX17205_AD_NSERIALNUMBER1,
+        MAX17205_AD_NSERIALNUMBER2,
+        MAX17205_AD_NDEVICENAME0,
+        MAX17205_AD_NDEVICENAME1,
+        MAX17205_AD_NDEVICENAME2,
+        MAX17205_AD_NDEVICENAME3,
+        MAX17205_AD_NDEVICENAME4,
+    };
 
-	//See table 19 on page 83 of the data sheet to see the list of non-volatile registers
-	dbgprintf("\r\nMAX17205 Non-Volatile Registers\r\n");
-	uint16_t reg_list[] = {
-			MAX17205_AD_NXTABLE0,
-			MAX17205_AD_NXTABLE1,
-			MAX17205_AD_NXTABLE2,
-			MAX17205_AD_NXTABLE3,
-			MAX17205_AD_NXTABLE4,
-			MAX17205_AD_NXTABLE5,
-			MAX17205_AD_NXTABLE6,
-			MAX17205_AD_NXTABLE7,
-			MAX17205_AD_NXTABLE8,
-			MAX17205_AD_NXTABLE9,
-			MAX17205_AD_NXTABLE10,
-			MAX17205_AD_NXTABLE11,
-			MAX17205_AD_NUSER18C,
-			MAX17205_AD_NUSER18D,
-			MAX17205_AD_NODSCTH,
-			MAX17205_AD_NODSCCFG,
-			MAX17205_AD_NOCVTABLE0,
-			MAX17205_AD_NOCVTABLE1,
-			MAX17205_AD_NOCVTABLE2,
-			MAX17205_AD_NOCVTABLE3,
-			MAX17205_AD_NOCVTABLE4,
-			MAX17205_AD_NOCVTABLE5,
-			MAX17205_AD_NOCVTABLE6,
-			MAX17205_AD_NOCVTABLE7,
-			MAX17205_AD_NOCVTABLE8,
-			MAX17205_AD_NOCVTABLE9,
-			MAX17205_AD_NOCVTABLE10,
-			MAX17205_AD_NOCVTABLE11,
-			MAX17205_AD_NICHGTERM,
-			MAX17205_AD_NFILTERCFG,
-			MAX17205_AD_NVEMPTY,
-			MAX17205_AD_NLEARNCFG,
-			MAX17205_AD_NQRTABLE00,
-			MAX17205_AD_NQRTABLE10,
-			MAX17205_AD_NQRTABLE20,
-			MAX17205_AD_NQRTABLE30,
-			MAX17205_AD_NCYCLES,
-			MAX17205_AD_NFULLCAPNOM,
-			MAX17205_AD_NRCOMP0,
-			MAX17205_AD_NTEMPCO,
-			MAX17205_AD_NIAVGEMPTY,
-			MAX17205_AD_NFULLCAPREP,
-			MAX17205_AD_NVOLTTEMP,
-			MAX17205_AD_NMAXMINCURR,
-			MAX17205_AD_NMAXMINVOLT,
-			MAX17205_AD_NMAXMINTEMP,
-			MAX17205_AD_NSOC,
-			MAX17205_AD_NTIMERH,
-			MAX17205_AD_NCONFIG,
-			MAX17205_AD_NRIPPLECFGCFG,
-			MAX17205_AD_NMISCCFG,
-			MAX17205_AD_NDESIGNCAP,
-			MAX17205_AD_NHIBCFG,
-			MAX17205_AD_NPACKCFG,
-			MAX17205_AD_NRELAXCFG,
-			MAX17205_AD_NCONVGCFG,
-			MAX17205_AD_NNVCFG0,
-			MAX17205_AD_NNVCFG1,
-			MAX17205_AD_NNVCFG2,
-			MAX17205_AD_NVALRTTH,
-			MAX17205_AD_NTALRTTH,
-			MAX17205_AD_NSALRTTH,
-			MAX17205_AD_NIALRTTH,
-			MAX17205_AD_NFULLSOCTHR,
-			MAX17205_AD_NTTFCFG,
-			MAX17205_AD_NCGAIN,
-			MAX17205_AD_NTCURVE,
-			MAX17205_AD_NTGAIN,
-			MAX17205_AD_NTOFF,
-			MAX17205_AD_NMANFCTRNAME0,
-			MAX17205_AD_NMANFCTRNAME1,
-			MAX17205_AD_NMANFCTRNAME2,
-			MAX17205_AD_NRSENSE,
-			MAX17205_AD_NUSER1D0,
-			MAX17205_AD_NUSER1D1,
-			MAX17205_AD_NAGEFCCFG,
-			MAX17205_AD_NDESIGNVOLTAGE,
-			MAX17205_AD_NUSER1D4,
-			MAX17205_AD_NRFASTVSHDN,
-			MAX17205_AD_NMANFCTRDATE,
-			MAX17205_AD_NFIRSTUSED,
-			MAX17205_AD_NSERIALNUMBER0,
-			MAX17205_AD_NSERIALNUMBER1,
-			MAX17205_AD_NSERIALNUMBER2,
-			MAX17205_AD_NDEVICENAME0,
-			MAX17205_AD_NDEVICENAME1,
-			MAX17205_AD_NDEVICENAME2,
-			MAX17205_AD_NDEVICENAME3,
-			MAX17205_AD_NDEVICENAME4,
-			0
-	};
-
-	for(int i = 0; reg_list[i] != 0;i++) {
-		if( max17205I2CReadRegister(config->i2cp, MAX17205_SA(MAX17205_AD_COMMAND), MAX17205_AD(reg_list[i]), buf.data, sizeof(buf.data)) == MSG_OK ) {
-			dbgprintf("   %-30s register 0x%X is 0x%X\r\n", max17205RegToStr(reg_list[i]), reg_list[i], buf.value);
-		}
-	}
-
-	return(MSG_OK);
+    for(size_t i = 0; i < ARRAYSIZE(reg_list); ++i) {
+        uint16_t buf = 0;
+        r = max17205Read(devp, reg_list[i], &buf);
+        if (r != MSG_OK) {
+            return r;
+        }
+        dbgprintf("   %-30s register 0x%X is 0x%X\r\n", max17205RegToStr(reg_list[i]), reg_list[i], buf);
+    }
+    return MSG_OK;
 }
 
 
 const char* max17205RegToStr(const uint16_t reg) {
-	switch (reg) {
-		case MAX17205_AD_AVGCELL1:
-			return ("MAX17205_AD_AVGCELL1");
-		case MAX17205_AD_AVGCELL2:
-			return ("MAX17205_AD_AVGCELL2");
-		case MAX17205_AD_AVGVCELL:
-			return("MAX17205_AD_AVGVCELL");
-		case MAX17205_AD_VCELL:
-			return("MAX17205_AD_VCELL");
-		case MAX17205_AD_FULLCAP:
-			return ("MAX17205_AD_FULLCAP");
-		case MAX17205_AD_AVCAP:
-			return ("MAX17205_AD_AVCAP");
-		case MAX17205_AD_FULLCAPREP:
-			return("MAX17205_AD_FULLCAPREP");
-		case MAX17205_AD_MIXCAP:
-			return ("MAX17205_AD_MIXCAP");
-		case MAX17205_AD_TTE:
-			return ("MAX17205_AD_TTE");
-		case MAX17205_AD_TTF:
-			return ("MAX17205_AD_TTF");
-		case MAX17205_AD_AVSOC:
-			return ("MAX17205_AD_AVSOC");
-		case MAX17205_AD_VFSOC:
-			return ("MAX17205_AD_VFSOC");
-		case MAX17205_AD_CYCLES:
-			return ("MAX17205_AD_CYCLES");
-		case MAX17205_AD_TEMP:
-			return("MAX17205_AD_TEMP");
-		case MAX17205_AD_CURRENT:
-			return("MAX17205_AD_CURRENT");
-		case MAX17205_AD_AVGCURRENT:
-			return("MAX17205_AD_AVGCURRENT");
-		case MAX17205_AD_BATT:
-			return("MAX17205_AD_BATT");
-		case MAX17205_AD_AVGTEMP1:
-			return("MAX17205_AD_AVGTEMP1");
-		case MAX17205_AD_TEMP1:
-			return("MAX17205_AD_TEMP1");
-		case MAX17205_AD_AVGTEMP2:
-			return("MAX17205_AD_AVGTEMP2");
-		case MAX17205_AD_AVGINTTEMP:
-			return("MAX17205_AD_AVGINTTEMP");
-		case MAX17205_AD_REPCAP:
-			return("MAX17205_AD_REPCAP");
-		case MAX17205_AD_PACKCFG:
-			return("MAX17205_AD_PACKCFG");
-		case MAX17205_AD_DESIGNCAP:
-			return("MAX17205_AD_DESIGNCAP");
-		case MAX17205_AD_REPSOC:
-			return("MAX17205_AD_REPSOC");
-
-
-		case MAX17205_AD_NXTABLE0:
-			return ("MAX17205_AD_NXTABLE0");
-		case MAX17205_AD_NXTABLE1:
-			return ("MAX17205_AD_NXTABLE1");
-		case MAX17205_AD_NXTABLE2:
-			return ("MAX17205_AD_NXTABLE2");
-		case MAX17205_AD_NXTABLE3:
-			return ("MAX17205_AD_NXTABLE3");
-		case MAX17205_AD_NXTABLE4:
-			return ("MAX17205_AD_NXTABLE4");
-		case MAX17205_AD_NXTABLE5:
-			return ("MAX17205_AD_NXTABLE5");
-		case MAX17205_AD_NXTABLE6:
-			return ("MAX17205_AD_NXTABLE6");
-		case MAX17205_AD_NXTABLE7:
-			return ("MAX17205_AD_NXTABLE7");
-		case MAX17205_AD_NXTABLE8:
-			return ("MAX17205_AD_NXTABLE8");
-		case MAX17205_AD_NXTABLE9:
-			return ("MAX17205_AD_NXTABLE9");
-		case MAX17205_AD_NXTABLE10:
-			return ("MAX17205_AD_NXTABLE10");
-		case MAX17205_AD_NXTABLE11:
-			return ("MAX17205_AD_NXTABLE11");
-		case MAX17205_AD_NUSER18C:
-			return ("MAX17205_AD_NUSER18C");
-		case MAX17205_AD_NUSER18D:
-			return ("MAX17205_AD_NUSER18D");
-		case MAX17205_AD_NODSCTH:
-			return ("MAX17205_AD_NODSCTH");
-		case MAX17205_AD_NODSCCFG:
-			return ("MAX17205_AD_NODSCCFG");
-		case MAX17205_AD_NOCVTABLE0:
-			return ("MAX17205_AD_NOCVTABLE0");
-		case MAX17205_AD_NOCVTABLE1:
-			return ("MAX17205_AD_NOCVTABLE1");
-		case MAX17205_AD_NOCVTABLE2:
-			return ("MAX17205_AD_NOCVTABLE2");
-		case MAX17205_AD_NOCVTABLE3:
-			return ("MAX17205_AD_NOCVTABLE3");
-		case MAX17205_AD_NOCVTABLE4:
-			return ("MAX17205_AD_NOCVTABLE4");
-		case MAX17205_AD_NOCVTABLE5:
-			return ("MAX17205_AD_NOCVTABLE5");
-		case MAX17205_AD_NOCVTABLE6:
-			return ("MAX17205_AD_NOCVTABLE6");
-		case MAX17205_AD_NOCVTABLE7:
-			return ("MAX17205_AD_NOCVTABLE7");
-		case MAX17205_AD_NOCVTABLE8:
-			return ("MAX17205_AD_NOCVTABLE8");
-		case MAX17205_AD_NOCVTABLE9:
-			return ("MAX17205_AD_NOCVTABLE9");
-		case MAX17205_AD_NOCVTABLE10:
-			return ("MAX17205_AD_NOCVTABLE10");
-		case MAX17205_AD_NOCVTABLE11:
-			return ("MAX17205_AD_NOCVTABLE11");
-		case MAX17205_AD_NICHGTERM:
-			return ("MAX17205_AD_NICHGTERM");
-		case MAX17205_AD_NFILTERCFG:
-			return ("MAX17205_AD_NFILTERCFG");
-		case MAX17205_AD_NVEMPTY:
-			return ("MAX17205_AD_NVEMPTY");
-		case MAX17205_AD_NLEARNCFG:
-			return ("MAX17205_AD_NLEARNCFG");
-		case MAX17205_AD_NQRTABLE00:
-			return ("MAX17205_AD_NQRTABLE00");
-		case MAX17205_AD_NQRTABLE10:
-			return ("MAX17205_AD_NQRTABLE10");
-		case MAX17205_AD_NQRTABLE20:
-			return ("MAX17205_AD_NQRTABLE20");
-		case MAX17205_AD_NQRTABLE30:
-			return ("MAX17205_AD_NQRTABLE30");
-		case MAX17205_AD_NCYCLES:
-			return ("MAX17205_AD_NCYCLES");
-		case MAX17205_AD_NFULLCAPNOM:
-			return ("MAX17205_AD_NFULLCAPNOM");
-		case MAX17205_AD_NRCOMP0:
-			return ("MAX17205_AD_NRCOMP0");
-		case MAX17205_AD_NTEMPCO:
-			return ("MAX17205_AD_NTEMPCO");
-		case MAX17205_AD_NIAVGEMPTY:
-			return ("MAX17205_AD_NIAVGEMPTY");
-		case MAX17205_AD_NFULLCAPREP:
-			return ("MAX17205_AD_NFULLCAPREP");
-		case MAX17205_AD_NVOLTTEMP:
-			return ("MAX17205_AD_NVOLTTEMP");
-		case MAX17205_AD_NMAXMINCURR:
-			return ("MAX17205_AD_NMAXMINCURR");
-		case MAX17205_AD_NMAXMINVOLT:
-			return ("MAX17205_AD_NMAXMINVOLT");
-		case MAX17205_AD_NMAXMINTEMP:
-			return ("MAX17205_AD_NMAXMINTEMP");
-		case MAX17205_AD_NSOC:
-			return ("MAX17205_AD_NSOC");
-		case MAX17205_AD_NTIMERH:
-			return ("MAX17205_AD_NTIMERH");
-		case MAX17205_AD_NCONFIG:
-			return ("MAX17205_AD_NCONFIG");
-		case MAX17205_AD_NRIPPLECFGCFG:
-			return ("MAX17205_AD_NRIPPLECFGCFG");
-		case MAX17205_AD_NMISCCFG:
-			return ("MAX17205_AD_NMISCCFG");
-		case MAX17205_AD_NDESIGNCAP:
-			return ("MAX17205_AD_NDESIGNCAP");
-		case MAX17205_AD_NHIBCFG:
-			return ("MAX17205_AD_NHIBCFG");
-
-		case MAX17205_AD_NPACKCFG:
-			return ("MAX17205_AD_NPACKCFG");
-		case MAX17205_AD_NRELAXCFG:
-			return ("MAX17205_AD_NRELAXCFG");
-		case MAX17205_AD_NCONVGCFG:
-			return ("MAX17205_AD_NCONVGCFG");
-		case MAX17205_AD_NNVCFG0:
-			return ("MAX17205_AD_NNVCFG0");
-		case MAX17205_AD_NNVCFG1:
-			return ("MAX17205_AD_NNVCFG1");
-		case MAX17205_AD_NNVCFG2:
-			return ("MAX17205_AD_NNVCFG2");
-		case MAX17205_AD_NVALRTTH:
-			return ("MAX17205_AD_NVALRTTH");
-		case MAX17205_AD_NTALRTTH:
-			return ("MAX17205_AD_NTALRTTH");
-		case MAX17205_AD_NSALRTTH:
-			return ("MAX17205_AD_NSALRTTH");
-		case MAX17205_AD_NIALRTTH:
-			return ("MAX17205_AD_NIALRTTH");
-		case MAX17205_AD_NFULLSOCTHR:
-			return ("MAX17205_AD_NFULLSOCTHR");
-		case MAX17205_AD_NTTFCFG:
-			return ("MAX17205_AD_NTTFCFG");
-		case MAX17205_AD_NCGAIN:
-			return ("MAX17205_AD_NCGAIN");
-		case MAX17205_AD_NTCURVE:
-			return ("MAX17205_AD_NTCURVE");
-		case MAX17205_AD_NTGAIN:
-			return ("MAX17205_AD_NTGAIN");
-		case MAX17205_AD_NTOFF:
-			return ("MAX17205_AD_NTOFF");
-		case MAX17205_AD_NMANFCTRNAME0:
-			return ("MAX17205_AD_NMANFCTRNAME0");
-		case MAX17205_AD_NMANFCTRNAME1:
-			return ("MAX17205_AD_NMANFCTRNAME1");
-		case MAX17205_AD_NMANFCTRNAME2:
-			return ("MAX17205_AD_NMANFCTRNAME2");
-		case MAX17205_AD_NRSENSE:
-			return ("MAX17205_AD_NRSENSE");
-		case MAX17205_AD_NUSER1D0:
-			return ("MAX17205_AD_NUSER1D0");
-		case MAX17205_AD_NUSER1D1:
-			return ("MAX17205_AD_NUSER1D1");
-		case MAX17205_AD_NAGEFCCFG:
-			return ("MAX17205_AD_NAGEFCCFG");
-		case MAX17205_AD_NDESIGNVOLTAGE:
-			return ("MAX17205_AD_NDESIGNVOLTAGE");
-		case MAX17205_AD_NUSER1D4:
-			return ("MAX17205_AD_NUSER1D4");
-		case MAX17205_AD_NRFASTVSHDN:
-			return ("MAX17205_AD_NRFASTVSHDN");
-		case MAX17205_AD_NMANFCTRDATE:
-			return ("MAX17205_AD_NMANFCTRDATE");
-		case MAX17205_AD_NFIRSTUSED:
-			return ("MAX17205_AD_NFIRSTUSED");
-		case MAX17205_AD_NSERIALNUMBER0:
-			return ("MAX17205_AD_NSERIALNUMBER0");
-		case MAX17205_AD_NSERIALNUMBER1:
-			return ("MAX17205_AD_NSERIALNUMBER1");
-		case MAX17205_AD_NSERIALNUMBER2:
-			return ("MAX17205_AD_NSERIALNUMBER2");
-		case MAX17205_AD_NDEVICENAME0:
-			return ("MAX17205_AD_NDEVICENAME0");
-		case MAX17205_AD_NDEVICENAME1:
-			return ("MAX17205_AD_NDEVICENAME1");
-		case MAX17205_AD_NDEVICENAME2:
-			return ("MAX17205_AD_NDEVICENAME2");
-		case MAX17205_AD_NDEVICENAME3:
-			return ("MAX17205_AD_NDEVICENAME3");
-		case MAX17205_AD_NDEVICENAME4:
-			return ("MAX17205_AD_NDEVICENAME4");
-
-	}
-
-	return("[reg?]");
+    switch (reg) {
+        case MAX17205_AD_AVGCELL1:
+            return "MAX17205_AD_AVGCELL1";
+        case MAX17205_AD_AVGCELL2:
+            return "MAX17205_AD_AVGCELL2";
+        case MAX17205_AD_AVGVCELL:
+            return "MAX17205_AD_AVGVCELL";
+        case MAX17205_AD_VCELL:
+            return "MAX17205_AD_VCELL";
+        case MAX17205_AD_FULLCAP:
+            return "MAX17205_AD_FULLCAP";
+        case MAX17205_AD_AVCAP:
+            return "MAX17205_AD_AVCAP";
+        case MAX17205_AD_FULLCAPREP:
+            return "MAX17205_AD_FULLCAPREP";
+        case MAX17205_AD_MIXCAP:
+            return "MAX17205_AD_MIXCAP";
+        case MAX17205_AD_TTE:
+            return "MAX17205_AD_TTE";
+        case MAX17205_AD_TTF:
+            return "MAX17205_AD_TTF";
+        case MAX17205_AD_AVSOC:
+            return "MAX17205_AD_AVSOC";
+        case MAX17205_AD_VFSOC:
+            return "MAX17205_AD_VFSOC";
+        case MAX17205_AD_CYCLES:
+            return "MAX17205_AD_CYCLES";
+        case MAX17205_AD_TEMP:
+            return "MAX17205_AD_TEMP";
+        case MAX17205_AD_CURRENT:
+            return "MAX17205_AD_CURRENT";
+        case MAX17205_AD_AVGCURRENT:
+            return "MAX17205_AD_AVGCURRENT";
+        case MAX17205_AD_BATT:
+            return "MAX17205_AD_BATT";
+        case MAX17205_AD_AVGTEMP1:
+            return "MAX17205_AD_AVGTEMP1";
+        case MAX17205_AD_TEMP1:
+            return "MAX17205_AD_TEMP1";
+        case MAX17205_AD_AVGTEMP2:
+            return "MAX17205_AD_AVGTEMP2";
+        case MAX17205_AD_AVGINTTEMP:
+            return "MAX17205_AD_AVGINTTEMP";
+        case MAX17205_AD_REPCAP:
+            return "MAX17205_AD_REPCAP";
+        case MAX17205_AD_PACKCFG:
+            return "MAX17205_AD_PACKCFG";
+        case MAX17205_AD_DESIGNCAP:
+            return "MAX17205_AD_DESIGNCAP";
+        case MAX17205_AD_REPSOC:
+            return "MAX17205_AD_REPSOC";
+        case MAX17205_AD_NXTABLE0:
+            return "MAX17205_AD_NXTABLE0";
+        case MAX17205_AD_NXTABLE1:
+            return "MAX17205_AD_NXTABLE1";
+        case MAX17205_AD_NXTABLE2:
+            return "MAX17205_AD_NXTABLE2";
+        case MAX17205_AD_NXTABLE3:
+            return "MAX17205_AD_NXTABLE3";
+        case MAX17205_AD_NXTABLE4:
+            return "MAX17205_AD_NXTABLE4";
+        case MAX17205_AD_NXTABLE5:
+            return "MAX17205_AD_NXTABLE5";
+        case MAX17205_AD_NXTABLE6:
+            return "MAX17205_AD_NXTABLE6";
+        case MAX17205_AD_NXTABLE7:
+            return "MAX17205_AD_NXTABLE7";
+        case MAX17205_AD_NXTABLE8:
+            return "MAX17205_AD_NXTABLE8";
+        case MAX17205_AD_NXTABLE9:
+            return "MAX17205_AD_NXTABLE9";
+        case MAX17205_AD_NXTABLE10:
+            return "MAX17205_AD_NXTABLE10";
+        case MAX17205_AD_NXTABLE11:
+            return "MAX17205_AD_NXTABLE11";
+        case MAX17205_AD_NUSER18C:
+            return "MAX17205_AD_NUSER18C";
+        case MAX17205_AD_NUSER18D:
+            return "MAX17205_AD_NUSER18D";
+        case MAX17205_AD_NODSCTH:
+            return "MAX17205_AD_NODSCTH";
+        case MAX17205_AD_NODSCCFG:
+            return "MAX17205_AD_NODSCCFG";
+        case MAX17205_AD_NOCVTABLE0:
+            return "MAX17205_AD_NOCVTABLE0";
+        case MAX17205_AD_NOCVTABLE1:
+            return "MAX17205_AD_NOCVTABLE1";
+        case MAX17205_AD_NOCVTABLE2:
+            return "MAX17205_AD_NOCVTABLE2";
+        case MAX17205_AD_NOCVTABLE3:
+            return "MAX17205_AD_NOCVTABLE3";
+        case MAX17205_AD_NOCVTABLE4:
+            return "MAX17205_AD_NOCVTABLE4";
+        case MAX17205_AD_NOCVTABLE5:
+            return "MAX17205_AD_NOCVTABLE5";
+        case MAX17205_AD_NOCVTABLE6:
+            return "MAX17205_AD_NOCVTABLE6";
+        case MAX17205_AD_NOCVTABLE7:
+            return "MAX17205_AD_NOCVTABLE7";
+        case MAX17205_AD_NOCVTABLE8:
+            return "MAX17205_AD_NOCVTABLE8";
+        case MAX17205_AD_NOCVTABLE9:
+            return "MAX17205_AD_NOCVTABLE9";
+        case MAX17205_AD_NOCVTABLE10:
+            return "MAX17205_AD_NOCVTABLE10";
+        case MAX17205_AD_NOCVTABLE11:
+            return "MAX17205_AD_NOCVTABLE11";
+        case MAX17205_AD_NICHGTERM:
+            return "MAX17205_AD_NICHGTERM";
+        case MAX17205_AD_NFILTERCFG:
+            return "MAX17205_AD_NFILTERCFG";
+        case MAX17205_AD_NVEMPTY:
+            return "MAX17205_AD_NVEMPTY";
+        case MAX17205_AD_NLEARNCFG:
+            return "MAX17205_AD_NLEARNCFG";
+        case MAX17205_AD_NQRTABLE00:
+            return "MAX17205_AD_NQRTABLE00";
+        case MAX17205_AD_NQRTABLE10:
+            return "MAX17205_AD_NQRTABLE10";
+        case MAX17205_AD_NQRTABLE20:
+            return "MAX17205_AD_NQRTABLE20";
+        case MAX17205_AD_NQRTABLE30:
+            return "MAX17205_AD_NQRTABLE30";
+        case MAX17205_AD_NCYCLES:
+            return "MAX17205_AD_NCYCLES";
+        case MAX17205_AD_NFULLCAPNOM:
+            return "MAX17205_AD_NFULLCAPNOM";
+        case MAX17205_AD_NRCOMP0:
+            return "MAX17205_AD_NRCOMP0";
+        case MAX17205_AD_NTEMPCO:
+            return "MAX17205_AD_NTEMPCO";
+        case MAX17205_AD_NIAVGEMPTY:
+            return "MAX17205_AD_NIAVGEMPTY";
+        case MAX17205_AD_NFULLCAPREP:
+            return "MAX17205_AD_NFULLCAPREP";
+        case MAX17205_AD_NVOLTTEMP:
+            return "MAX17205_AD_NVOLTTEMP";
+        case MAX17205_AD_NMAXMINCURR:
+            return "MAX17205_AD_NMAXMINCURR";
+        case MAX17205_AD_NMAXMINVOLT:
+            return "MAX17205_AD_NMAXMINVOLT";
+        case MAX17205_AD_NMAXMINTEMP:
+            return "MAX17205_AD_NMAXMINTEMP";
+        case MAX17205_AD_NSOC:
+            return "MAX17205_AD_NSOC";
+        case MAX17205_AD_NTIMERH:
+            return "MAX17205_AD_NTIMERH";
+        case MAX17205_AD_NCONFIG:
+            return "MAX17205_AD_NCONFIG";
+        case MAX17205_AD_NRIPPLECFGCFG:
+            return "MAX17205_AD_NRIPPLECFGCFG";
+        case MAX17205_AD_NMISCCFG:
+            return "MAX17205_AD_NMISCCFG";
+        case MAX17205_AD_NDESIGNCAP:
+            return "MAX17205_AD_NDESIGNCAP";
+        case MAX17205_AD_NHIBCFG:
+            return "MAX17205_AD_NHIBCFG";
+        case MAX17205_AD_NPACKCFG:
+            return "MAX17205_AD_NPACKCFG";
+        case MAX17205_AD_NRELAXCFG:
+            return "MAX17205_AD_NRELAXCFG";
+        case MAX17205_AD_NCONVGCFG:
+            return "MAX17205_AD_NCONVGCFG";
+        case MAX17205_AD_NNVCFG0:
+            return "MAX17205_AD_NNVCFG0";
+        case MAX17205_AD_NNVCFG1:
+            return "MAX17205_AD_NNVCFG1";
+        case MAX17205_AD_NNVCFG2:
+            return "MAX17205_AD_NNVCFG2";
+        case MAX17205_AD_NVALRTTH:
+            return "MAX17205_AD_NVALRTTH";
+        case MAX17205_AD_NTALRTTH:
+            return "MAX17205_AD_NTALRTTH";
+        case MAX17205_AD_NSALRTTH:
+            return "MAX17205_AD_NSALRTTH";
+        case MAX17205_AD_NIALRTTH:
+            return "MAX17205_AD_NIALRTTH";
+        case MAX17205_AD_NFULLSOCTHR:
+            return "MAX17205_AD_NFULLSOCTHR";
+        case MAX17205_AD_NTTFCFG:
+            return "MAX17205_AD_NTTFCFG";
+        case MAX17205_AD_NCGAIN:
+            return "MAX17205_AD_NCGAIN";
+        case MAX17205_AD_NTCURVE:
+            return "MAX17205_AD_NTCURVE";
+        case MAX17205_AD_NTGAIN:
+            return "MAX17205_AD_NTGAIN";
+        case MAX17205_AD_NTOFF:
+            return "MAX17205_AD_NTOFF";
+        case MAX17205_AD_NMANFCTRNAME0:
+            return "MAX17205_AD_NMANFCTRNAME0";
+        case MAX17205_AD_NMANFCTRNAME1:
+            return "MAX17205_AD_NMANFCTRNAME1";
+        case MAX17205_AD_NMANFCTRNAME2:
+            return "MAX17205_AD_NMANFCTRNAME2";
+        case MAX17205_AD_NRSENSE:
+            return "MAX17205_AD_NRSENSE";
+        case MAX17205_AD_NUSER1D0:
+            return "MAX17205_AD_NUSER1D0";
+        case MAX17205_AD_NUSER1D1:
+            return "MAX17205_AD_NUSER1D1";
+        case MAX17205_AD_NAGEFCCFG:
+            return "MAX17205_AD_NAGEFCCFG";
+        case MAX17205_AD_NDESIGNVOLTAGE:
+            return "MAX17205_AD_NDESIGNVOLTAGE";
+        case MAX17205_AD_NUSER1D4:
+            return "MAX17205_AD_NUSER1D4";
+        case MAX17205_AD_NRFASTVSHDN:
+            return "MAX17205_AD_NRFASTVSHDN";
+        case MAX17205_AD_NMANFCTRDATE:
+            return "MAX17205_AD_NMANFCTRDATE";
+        case MAX17205_AD_NFIRSTUSED:
+            return "MAX17205_AD_NFIRSTUSED";
+        case MAX17205_AD_NSERIALNUMBER0:
+            return "MAX17205_AD_NSERIALNUMBER0";
+        case MAX17205_AD_NSERIALNUMBER1:
+            return "MAX17205_AD_NSERIALNUMBER1";
+        case MAX17205_AD_NSERIALNUMBER2:
+            return "MAX17205_AD_NSERIALNUMBER2";
+        case MAX17205_AD_NDEVICENAME0:
+            return "MAX17205_AD_NDEVICENAME0";
+        case MAX17205_AD_NDEVICENAME1:
+            return "MAX17205_AD_NDEVICENAME1";
+        case MAX17205_AD_NDEVICENAME2:
+            return "MAX17205_AD_NDEVICENAME2";
+        case MAX17205_AD_NDEVICENAME3:
+            return "MAX17205_AD_NDEVICENAME3";
+        case MAX17205_AD_NDEVICENAME4:
+            return "MAX17205_AD_NDEVICENAME4";
+    }
+    return "[reg?]";
 }
 
 /** @} */

--- a/common/worker.c
+++ b/common/worker.c
@@ -64,7 +64,7 @@ thread_t *start_worker(worker_t *wp)
 
 msg_t stop_worker(worker_t *wp)
 {
-    msg_t ret;
+    msg_t ret = MSG_OK;
 
     osalDbgCheck(wp != NULL);
 

--- a/src/f0/app_battery/Makefile
+++ b/src/f0/app_battery/Makefile
@@ -187,7 +187,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = -DCO_VERSION_MAJOR=4
+UDEFS = -DCO_VERSION_MAJOR=4 -DDEBUG_PRINT
 
 # Define ASM defines here
 UADEFS =

--- a/src/f0/app_battery/main.c
+++ b/src/f0/app_battery/main.c
@@ -1,29 +1,16 @@
-/*
-    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
-
-/* ChibiOS header files */
 #include "ch.h"
 #include "hal.h"
-#include "chprintf.h"
 
-/* Project header files */
 #include "oresat.h"
 #include "batt.h"
 
-#define DEBUG_SERIAL    (BaseSequentialStream*) &SD2
+#ifdef DEBUG_PRINT
+#include "chprintf.h"
+#define DEBUG_SD (BaseSequentialStream *) &SD2
+#define dbgprintf(str, ...) chprintf(DEBUG_SD, str, ##__VA_ARGS__)
+#else
+#define dbgprintf(str, ...)
+#endif
 
 static worker_t battery_worker;
 static thread_descriptor_t battery_worker_desc = {
@@ -41,27 +28,33 @@ static oresat_config_t oresat_conf = {
     .bitrate = ORESAT_DEFAULT_BITRATE,
 };
 
-/**
- * @brief App Initialization
- */
-static void app_init(void)
-{
-    /* App initialization */
-    reg_worker(&battery_worker, &battery_worker_desc, true, true);
+static const I2CConfig i2cconfig_1 = {
+    STM32_TIMINGR_PRESC(0xBU) |
+    STM32_TIMINGR_SCLDEL(0x4U) | STM32_TIMINGR_SDADEL(0x2U) |
+    STM32_TIMINGR_SCLH(0xFU)  | STM32_TIMINGR_SCLL(0x13U),
+    0,
+    0
+};
 
-    /* Start up debug output */
-    sdStart(&SD2, NULL);
-}
+//TODO timing for i2c2 is different the i2c1. Scope the lines and match them up.
+static const I2CConfig i2cconfig_2 = {
+    STM32_TIMINGR_PRESC(0xFU) |
+    STM32_TIMINGR_SCLDEL(0x4U) | STM32_TIMINGR_SDADEL(0x2U) |
+    STM32_TIMINGR_SCLH(0xFU)  | STM32_TIMINGR_SCLL(0x13U),
+    0,
+    0
+};
 
-/**
- * @brief Main Application
- */
-int main(void)
-{
-    // Initialize and start
+int main(void) {
     oresat_init(&oresat_conf);
-    app_init();
-    chprintf(DEBUG_SERIAL, "\r\nStarting battery app...\r\n");
+#ifdef DEBUG_PRINT
+    sdStart(&SD2, NULL);
+#endif
+    dbgprintf("\r\nStarting battery Node ID: 0x%x\r\n", oresat_conf.node_id);
+
+    i2cStart(&I2CD1, &i2cconfig_1);
+    i2cStart(&I2CD2, &i2cconfig_2);
+    reg_worker(&battery_worker, &battery_worker_desc, true, true);
 
     oresat_start();
     return 0;

--- a/src/f0/app_battery/source/batt.c
+++ b/src/f0/app_battery/source/batt.c
@@ -9,8 +9,8 @@
 
 #ifdef DEBUG_PRINT
 #include "chprintf.h"
-#define DEBUG_SD (BaseSequentialStream *) &SD2
-#define dbgprintf(str, ...) chprintf(DEBUG_SD, str, ##__VA_ARGS__)
+#define DEBUG_SD &SD2
+#define dbgprintf(str, ...) chprintf((BaseSequentialStream *)DEBUG_SD, str, ##__VA_ARGS__)
 #else
 #define dbgprintf(str, ...)
 #endif
@@ -389,7 +389,7 @@ msg_t prompt_nv_memory_write(MAX17205Driver *devp, const char *pack_str) {
 
 #if ENABLE_NV_MEMORY_UPDATE_CODE && defined(DEBUG_PRINT)
     dbgprintf("One or more NV Ram elements don't match expected values...\r\n");
-    r = max17205WriteRegisters(bat_nv_programing_cfg, ARRAY_LEN(batt_nv_programing_cfg));
+    r = max17205WriteRegisters(devp, batt_nv_programing_cfg, ARRAY_LEN(batt_nv_programing_cfg));
     if (r != MSG_OK) {
         dbgprintf("Failed to write new nv reg values\n");
         return r;
@@ -409,7 +409,7 @@ msg_t prompt_nv_memory_write(MAX17205Driver *devp, const char *pack_str) {
 
     dbgprintf("Write NV memory on MAX17205 for %s ? y/n? ", pack_str);
     uint8_t ch = 0;
-    sdRead(&DEBUG_SD, &ch, 1);
+    sdRead(DEBUG_SD, &ch, 1);
     dbgprintf("\r\n");
 
     if (ch == 'y') {

--- a/src/f0/app_battery/source/batt.c
+++ b/src/f0/app_battery/source/batt.c
@@ -3,6 +3,7 @@
 #include "max17205.h"
 #include "CANopen.h"
 #include "OD.h"
+#include <sys/param.h>
 
 #define ENABLE_NV_MEMORY_UPDATE_CODE      0
 
@@ -99,8 +100,8 @@ typedef struct {
     uint16_t v_cell_2_mV;
     uint16_t v_cell_mV;
     uint16_t v_cell_avg_mV;
-    uint8_t v_cell_max_volt_mV;
-    uint8_t v_cell_min_volt_mV;
+    uint16_t v_cell_max_volt_mV;
+    uint16_t v_cell_min_volt_mV;
 
     int16_t current_mA;
     int16_t avg_current_mA;
@@ -111,8 +112,8 @@ typedef struct {
     uint16_t present_state_of_charge; //Percent
     uint16_t reported_state_of_charge; //Percent
 
-    uint16_t time_to_full_seconds;
-    uint16_t time_to_empty_seconds;
+    uint32_t time_to_full_seconds;
+    uint32_t time_to_empty_seconds;
 
     uint16_t full_capacity_mAh;
     uint16_t available_capacity_mAh;
@@ -277,7 +278,7 @@ bool populate_pack_data(MAX17205Driver *driver, batt_pack_data_t *dest) {
     if( (r = max17205ReadVoltage(driver, MAX17205_AD_VCELL, &dest->v_cell_mV)) != MSG_OK ) {
         dest->is_data_valid = false;
     }
-    if( (r = max17205ReadBattVoltage(driver, MAX17205_AD_BATT, &dest->batt_mV)) != MSG_OK ) {
+    if( (r = max17205ReadBatt(driver, &dest->batt_mV)) != MSG_OK ) {
         dest->is_data_valid = false;
     }
 
@@ -460,8 +461,8 @@ void populate_od_pack_data(batt_pack_data_t *pack_data) {
         OD_RAM.x4000_pack_1.current_min = pack_data->min_current_mA;
         OD_RAM.x4000_pack_1.full_capacity = pack_data->full_capacity_mAh;
         OD_RAM.x4000_pack_1.reported_capacity = pack_data->reported_capacity_mAh;
-        OD_RAM.x4000_pack_1.time_to_empty = pack_data->time_to_empty_seconds;
-        OD_RAM.x4000_pack_1.time_to_full = pack_data->time_to_full_seconds;
+        OD_RAM.x4000_pack_1.time_to_empty = MIN(pack_data->time_to_empty_seconds, UINT16_MAX);
+        OD_RAM.x4000_pack_1.time_to_full = MIN(pack_data->time_to_full_seconds, UINT16_MAX);
         OD_RAM.x4000_pack_1.cycles = pack_data->cycles;
         OD_RAM.x4000_pack_1.reported_state_of_charge = pack_data->reported_state_of_charge;
         OD_RAM.x4000_pack_1.temperature = (int8_t)(pack_data->temp_1_C);
@@ -501,8 +502,8 @@ void populate_od_pack_data(batt_pack_data_t *pack_data) {
         OD_RAM.x4001_pack_2.current_min = pack_data->min_current_mA;
         OD_RAM.x4001_pack_2.full_capacity = pack_data->full_capacity_mAh;
         OD_RAM.x4001_pack_2.reported_capacity = pack_data->reported_capacity_mAh;
-        OD_RAM.x4001_pack_2.time_to_empty = pack_data->time_to_empty_seconds;
-        OD_RAM.x4001_pack_2.time_to_full = pack_data->time_to_full_seconds;
+        OD_RAM.x4001_pack_2.time_to_empty = MIN(pack_data->time_to_empty_seconds, UINT16_MAX);
+        OD_RAM.x4001_pack_2.time_to_full = MIN(pack_data->time_to_full_seconds, UINT16_MAX);
         OD_RAM.x4001_pack_2.cycles = pack_data->cycles;
         OD_RAM.x4001_pack_2.reported_state_of_charge = pack_data->reported_state_of_charge;
         OD_RAM.x4001_pack_2.temperature = (int8_t)(pack_data->temp_1_C);

--- a/src/f0/app_battery/source/batt.c
+++ b/src/f0/app_battery/source/batt.c
@@ -16,6 +16,7 @@
 #endif
 
 #define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+#define CLAMP(val, low, high) MIN(MAX(val, low), high)
 
 #define NCELLS          2U          /* Number of cells */
 
@@ -96,7 +97,7 @@ typedef struct {
     bool is_data_valid;
     uint8_t pack_number;
 
-    uint16_t batt_mV;
+    uint32_t batt_mV;
     uint16_t v_cell_1_mV;
     uint16_t v_cell_2_mV;
     uint16_t v_cell_mV;
@@ -104,22 +105,22 @@ typedef struct {
     uint16_t v_cell_max_volt_mV;
     uint16_t v_cell_min_volt_mV;
 
-    int16_t current_mA;
-    int16_t avg_current_mA;
-    int16_t max_current_mA;
-    int16_t min_current_mA;
+    int32_t current_mA;
+    int32_t avg_current_mA;
+    int32_t max_current_mA;
+    int32_t min_current_mA;
 
-    uint16_t available_state_of_charge; //Percent
-    uint16_t present_state_of_charge; //Percent
-    uint16_t reported_state_of_charge; //Percent
+    uint8_t available_state_of_charge; //Percent
+    uint8_t present_state_of_charge; //Percent
+    uint8_t reported_state_of_charge; //Percent
 
     uint32_t time_to_full_seconds;
     uint32_t time_to_empty_seconds;
 
-    uint16_t full_capacity_mAh;
-    uint16_t available_capacity_mAh;
-    uint16_t mix_capacity_mAh;
-    uint16_t reported_capacity_mAh;
+    uint32_t full_capacity_mAh;
+    uint32_t available_capacity_mAh;
+    uint32_t mix_capacity_mAh;
+    uint32_t reported_capacity_mAh;
 
     uint16_t cycles; // count
 
@@ -434,25 +435,25 @@ void populate_od_pack_data(batt_pack_data_t *pack_data) {
     uint8_t state_bitmask = 0;
 
     if (pack_data->pack_number == 1) {
-        OD_RAM.x4000_pack_1.vbatt = pack_data->batt_mV;
+        OD_RAM.x4000_pack_1.vbatt = MIN(pack_data->batt_mV, UINT16_MAX);
         OD_RAM.x4000_pack_1.vcell_max = pack_data->v_cell_max_volt_mV;
         OD_RAM.x4000_pack_1.vcell_min = pack_data->v_cell_min_volt_mV;
         OD_RAM.x4000_pack_1.vcell = pack_data->v_cell_mV;
         OD_RAM.x4000_pack_1.vcell_1 = pack_data->v_cell_1_mV;
         OD_RAM.x4000_pack_1.vcell_2 = pack_data->v_cell_2_mV;
         OD_RAM.x4000_pack_1.vcell_avg = pack_data->v_cell_avg_mV;
-        OD_RAM.x4000_pack_1.current = pack_data->current_mA;
-        OD_RAM.x4000_pack_1.current_avg = pack_data->avg_current_mA;
-        OD_RAM.x4000_pack_1.current_max = pack_data->max_current_mA;
-        OD_RAM.x4000_pack_1.current_min = pack_data->min_current_mA;
-        OD_RAM.x4000_pack_1.full_capacity = pack_data->full_capacity_mAh;
-        OD_RAM.x4000_pack_1.reported_capacity = pack_data->reported_capacity_mAh;
+        OD_RAM.x4000_pack_1.current = CLAMP(pack_data->current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4000_pack_1.current_avg = CLAMP(pack_data->avg_current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4000_pack_1.current_max = CLAMP(pack_data->max_current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4000_pack_1.current_min = CLAMP(pack_data->min_current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4000_pack_1.full_capacity = MIN(pack_data->full_capacity_mAh, UINT16_MAX);
+        OD_RAM.x4000_pack_1.reported_capacity = MIN(pack_data->reported_capacity_mAh, UINT16_MAX);
         OD_RAM.x4000_pack_1.time_to_empty = MIN(pack_data->time_to_empty_seconds, UINT16_MAX);
         OD_RAM.x4000_pack_1.time_to_full = MIN(pack_data->time_to_full_seconds, UINT16_MAX);
         OD_RAM.x4000_pack_1.cycles = pack_data->cycles;
         OD_RAM.x4000_pack_1.reported_state_of_charge = pack_data->reported_state_of_charge;
-        OD_RAM.x4000_pack_1.temperature = (int8_t)(pack_data->temp_1_C);
-        OD_RAM.x4000_pack_1.temperature_avg = (int8_t)(pack_data->avg_temp_1_C);
+        OD_RAM.x4000_pack_1.temperature = CLAMP(pack_data->temp_1_C, INT8_MIN, INT8_MAX);
+        OD_RAM.x4000_pack_1.temperature_avg = CLAMP(pack_data->avg_temp_1_C, INT8_MIN, INT8_MAX);
         OD_RAM.x4000_pack_1.temperature_min = pack_data->temp_min_C;
         OD_RAM.x4000_pack_1.temperature_max = pack_data->temp_max_C;
 
@@ -473,27 +474,25 @@ void populate_od_pack_data(batt_pack_data_t *pack_data) {
         }
         OD_RAM.x4000_pack_1.status = state_bitmask;
     } else if (pack_data->pack_number == 2) {
-        OD_RAM.x4001_pack_2.vbatt = pack_data->batt_mV;
-        OD_RAM.x4001_pack_2.vcell_max = pack_data->v_cell_max_volt_mV;
-        OD_RAM.x4001_pack_2.vbatt = pack_data->batt_mV;
+        OD_RAM.x4001_pack_2.vbatt = MIN(pack_data->batt_mV, UINT16_MAX);
         OD_RAM.x4001_pack_2.vcell_max = pack_data->v_cell_max_volt_mV;
         OD_RAM.x4001_pack_2.vcell_min = pack_data->v_cell_min_volt_mV;
         OD_RAM.x4001_pack_2.vcell = pack_data->v_cell_mV;
         OD_RAM.x4001_pack_2.vcell_1 = pack_data->v_cell_1_mV;
         OD_RAM.x4001_pack_2.vcell_2 = pack_data->v_cell_2_mV;
         OD_RAM.x4001_pack_2.vcell_avg = pack_data->v_cell_avg_mV;
-        OD_RAM.x4001_pack_2.current = pack_data->current_mA;
-        OD_RAM.x4001_pack_2.current_avg = pack_data->avg_current_mA;
-        OD_RAM.x4001_pack_2.current_max = pack_data->max_current_mA;
-        OD_RAM.x4001_pack_2.current_min = pack_data->min_current_mA;
-        OD_RAM.x4001_pack_2.full_capacity = pack_data->full_capacity_mAh;
-        OD_RAM.x4001_pack_2.reported_capacity = pack_data->reported_capacity_mAh;
+        OD_RAM.x4001_pack_2.current = CLAMP(pack_data->current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4001_pack_2.current_avg = CLAMP(pack_data->avg_current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4001_pack_2.current_max = CLAMP(pack_data->max_current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4001_pack_2.current_min = CLAMP(pack_data->min_current_mA, INT16_MIN, INT16_MAX);
+        OD_RAM.x4001_pack_2.full_capacity = MIN(pack_data->full_capacity_mAh, UINT16_MAX);
+        OD_RAM.x4001_pack_2.reported_capacity = MIN(pack_data->reported_capacity_mAh, UINT16_MAX);
         OD_RAM.x4001_pack_2.time_to_empty = MIN(pack_data->time_to_empty_seconds, UINT16_MAX);
         OD_RAM.x4001_pack_2.time_to_full = MIN(pack_data->time_to_full_seconds, UINT16_MAX);
         OD_RAM.x4001_pack_2.cycles = pack_data->cycles;
         OD_RAM.x4001_pack_2.reported_state_of_charge = pack_data->reported_state_of_charge;
-        OD_RAM.x4001_pack_2.temperature = (int8_t)(pack_data->temp_1_C);
-        OD_RAM.x4001_pack_2.temperature_avg = (int8_t)(pack_data->avg_temp_1_C);
+        OD_RAM.x4001_pack_2.temperature = CLAMP(pack_data->temp_1_C, INT8_MIN, INT8_MAX);
+        OD_RAM.x4001_pack_2.temperature_avg = CLAMP(pack_data->avg_temp_1_C, INT8_MIN, INT8_MAX);
         OD_RAM.x4001_pack_2.temperature_min = pack_data->temp_min_C;
         OD_RAM.x4001_pack_2.temperature_max = pack_data->temp_max_C;
 


### PR DESCRIPTION
This doesn't have significant behavior changes, it mostly brings it in line with other firmware. Changes include:
- Removing template text. Template stuff should have been removed during actual implementation
- Require I2C and I2C mutual exclusion. The conditional compilation without those two features was untested and never worked. It also doesn't make sense to have this driver without I2C.
- Removed unused VMT features
- Made RSENSE a runtime/config property. It was previously a mix of hard coded to 0.01 and read from a user set register. One day we'll be cool enough to calibrate each board individually.
- Consistently use spaces instead of tabs. As much as I'd prefer tabs this project standardized on spaces.
- Fixed if and return formatting. There's no need to put parenthesis around return values, return is not a function.
- Return early on errors to avoid excessive nesting.
- Rewrite the base register access functions into max17205Read/Write that handle as much boiler plate as is reasonable. Locking, address determination, serialization.
- Standardized dbgprintf to be conditional on the makefile defined PRINT_DEBUG macro.
- Moved MaxMin register reads to the driver so users don't have to deal with converting raw register values.