### PR TITLE
Fix compile error when OD_CNT_TPDO is defined but 0

### DIFF
--- a/src/f0/app_devboard/cfg/CO_driver_custom.h
+++ b/src/f0/app_devboard/cfg/CO_driver_custom.h
@@ -5,6 +5,17 @@
 extern "C" {
 #endif
 
+// See CANopenNode/CANopen.c lines 181 - 192. I'm 80% sure that it's a bug in
+// the library that it doesn't handle the case where OD_CNT_{T,R}PDO is defined
+// but zero; as written it only compiles when they're either undefined or
+// greater than zero. None of the firmware projects use RPDOs so they've been
+// disabled in CO_CONFIG_PDO (common/include/CO_driver_target.h) but this is
+// one of the few project that also doesn't do TPDOs. Our generated object
+// dictionaries (od/OD.h) always define OD_CNT_{T,R}PDO. The two defines below
+// are what CANopen does when OD_CNT_TPDO is undefined and should probably do
+// also when they are defined but zero.
+#define OD_ENTRY_H1800 NULL
+#define OD_ENTRY_H1A00 NULL
 
 #ifdef __cplusplus
 }

--- a/src/f0/app_protocard/cfg/CO_driver_custom.h
+++ b/src/f0/app_protocard/cfg/CO_driver_custom.h
@@ -5,6 +5,17 @@
 extern "C" {
 #endif
 
+// See CANopenNode/CANopen.c lines 181 - 192. I'm 80% sure that it's a bug in
+// the library that it doesn't handle the case where OD_CNT_{T,R}PDO is defined
+// but zero; as written it only compiles when they're either undefined or
+// greater than zero. None of the firmware projects use RPDOs so they've been
+// disabled in CO_CONFIG_PDO (common/include/CO_driver_target.h) but this is
+// one of the few project that also doesn't do TPDOs. Our generated object
+// dictionaries (od/OD.h) always define OD_CNT_{T,R}PDO. The two defines below
+// are what CANopen does when OD_CNT_TPDO is undefined and should probably do
+// also when they are defined but zero.
+#define OD_ENTRY_H1800 NULL
+#define OD_ENTRY_H1A00 NULL
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In upgrading to `oresat-configs 0.8.0` the OD generator had a minor change where `OD_CNT_{T,R}PDO` are now always defined even when zero (which seems reasonable to me) where previously they were not defined if there were none. CANopenNode is apparently unable to handle this though when PDOs are enabled in `CO_CONFIG_PDO`. I'm 80% sure this is just a bug in CANopenNode, see the comments in the patch for details.

I've gone with what I consider the minimally invasive fix , doing what CANopenNode should be doing but per firmware app in `CO_driver_custom.h`, but I can see a few other ways of fixing it that may be better:
-  Restore the previous OD generator behavior where it doesn't define OD_CNT_* when the value is 0. This would require a new quick release of `oresat-configs`.
- Have the OD generator also generate `CO_CONFIG_PDO`, unsetting the enable TPDO or RPDO flag when there are none. This leads to a couple more unused variable compiler warnings and would require a new `oresat-configs` release.
- Patch CANopenNode, which seems unlikely with all the hassle involved in that.
- What this patch does, which fixes things on a per-app basis. 

@ryanpdx thoughts?