### PR TITLE
Use oresat-configs v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Tools required:
 * oresat-configs
 
 To install oresat-configs:
-* `$ pip install oresat-configs`
+* `$ pip install --user oresat-configs~=1.0.0`
 
 Please refer to [Platform Specific Installation Instructions](doc/toolchain.md)
 for details on how to do this on a per-system basis.

--- a/common/include/version.h
+++ b/common/include/version.h
@@ -1,0 +1,14 @@
+#ifndef _VERSION_H_
+#define _VERSION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void version_extension_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/common/od.yaml
+++ b/common/od.yaml
@@ -1,0 +1,116 @@
+name: firmware
+nice_name: Firmware
+
+std_objects:
+  - device_type
+  - error_register
+  - predefined_error_field
+  - cob_id_sync
+  - communication_cycle_period
+  - cob_id_emergency_message
+  - inhibit_time_emcy
+  - producer_heartbeat_time
+  - identity
+  - synchronous_counter_overflow_value
+  - sdo_server_parameter
+  - scet
+  - utc
+
+objects:
+  - index: 0x3000
+    name: satellite_id
+    data_type: uint8
+    description: the unique oresat satellite id
+    access_type: const
+
+  - index: 0x3001
+    name: flight_mode
+    data_type: bool
+    description: card is in flight mode
+    access_type: ro
+    default: true
+
+  - index: 0x3002
+    name: versions
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: hw_version
+        data_type: str
+        description: card hw version
+        access_type: const
+        default: "0.0"
+
+      - subindex: 0x2
+        name: configs_version
+        data_type: str
+        description: oresat configs version
+        access_type: const
+        default: "0.0.0"
+
+      # subindex 0x3 reserved
+
+      - subindex: 0x4
+        name: fw_version
+        data_type: str
+        description: app fw version
+        access_type: const
+        default: "0.0.0"
+
+  - index: 0x3003
+    name: system
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: reset
+        data_type: uint8
+        description: reset the app
+        value_descriptions:
+          no_stop: 0
+          soft_reset: 1
+          hard_reset: 2
+          factory_reset: 3
+          poweroff: 4
+        access_type: wo
+
+      # subindex 0x2 reserved for storage_percent
+      # subindex 0x3 reserved for ram_percent
+      # subindex 0x4 reserved for unix_time
+
+      - subindex: 0x5
+        name: uptime
+        data_type: uint32
+        description: uptime
+        access_type: ro
+        unit: s
+
+      # subindex 0x6 reserved for power_cycles
+
+      - subindex: 0x7
+        name: temperature
+        data_type: int8
+        description: processor temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x8
+        name: vrefint
+        description: processor internal voltage reference
+        data_type: uint16
+        access_type: ro
+        scale_factor: 0.001
+        unit: V
+
+        # subindex 0x9 reserved for boot_select
+
+  # index 0x3004 reserved
+  # index 0x3005 reserved
+  # index 0x3006 reserved
+  # index 0x3007 reserved
+  # index 0x3008 reserved
+
+  - index: 0x3009
+    name: board_id
+    data_type: uint8
+    description: the unique board id for the board revision
+    access_type: const

--- a/common/oresat.c
+++ b/common/oresat.c
@@ -2,6 +2,7 @@
 #include "sensors.h"
 #include "CO_threads.h"
 #include "CANopen.h"
+#include "version.h"
 
 CO_t *CO;
 CANDriver *cand;
@@ -45,6 +46,8 @@ void oresat_init(oresat_config_t *config)
 
     /* Initialize CANopen Subsystem */
     CO_init(&CO, cand, config->node_id, config->bitrate, config->fifo1_filters, config->filter_count);
+
+    version_extension_init();
 
     return;
 }

--- a/common/oresat.mk
+++ b/common/oresat.mk
@@ -1,5 +1,6 @@
 include $(PROJ_SRC)/CANopen.mk
 include $(PROJ_SRC)/util.mk
+include $(PROJ_SRC)/version.mk
 
 PROJINC       = $(PROJ_SRC)/include
 

--- a/common/version.c
+++ b/common/version.c
@@ -1,0 +1,44 @@
+#include "version.h"
+#include "301/CO_ODinterface.h"
+#include "OD.h"
+#include <string.h>
+
+static ODR_t version_read(OD_stream_t *stream, void *buf, OD_size_t count, OD_size_t *countRead);
+
+static OD_extension_t ext = {
+    .object = NULL,
+    .read = version_read,
+    .write = OD_writeOriginal,
+};
+
+void version_extension_init(void) {
+    OD_entry_t *entry = OD_find(OD, OD_INDEX_VERSIONS);
+    if (entry != NULL) {
+        OD_extension_init(entry, &ext);
+    }
+}
+
+static ODR_t version_read(OD_stream_t *stream, void *buf, OD_size_t count, OD_size_t *countRead) {
+    ODR_t r = ODR_DATA_LOC_CTRL;
+    void *p = NULL;
+    switch (stream->subIndex) {
+    case OD_SUBINDEX_VERSIONS_HW_VERSION:
+        memcpy(buf, BOARD_NAME, strlen(BOARD_NAME) + 1);
+        if (p) {
+            *countRead = strlen(BOARD_NAME) + 1;
+            r = ODR_OK;
+        }
+        break;
+    case OD_SUBINDEX_VERSIONS_FW_VERSION:
+        p = memcpy(buf, FW_VERSION, strlen(FW_VERSION) + 1);
+        if (p) {
+            *countRead = strlen(FW_VERSION) + 1;
+            r = ODR_OK;
+        }
+        break;
+    default:
+        r = OD_readOriginal(stream, buf, count, countRead);
+        break;
+    }
+    return r;
+}

--- a/common/version.mk
+++ b/common/version.mk
@@ -1,0 +1,9 @@
+# List of all the VERSION device files.
+VERSIONSRC := $(PROJ_SRC)/version.c
+
+# Required include directories
+VERSIONINC := $(PROJ_SRC)/include
+
+# Shared variables
+ALLCSRC += $(VERSIONSRC)
+ALLINC  += $(VERSIONINC)

--- a/src/f0/app_adcs/Makefile
+++ b/src/f0/app_adcs/Makefile
@@ -107,16 +107,16 @@ DEPDIR   := $(APP_ROOT)/.dep
 BOARDDIR  = $(PROJ_ROOT)/boards/$(BOARD)
 
 ODDIR    := $(APP_ROOT)/od
-ifeq ($(ORESAT),)
-  ORESAT = 0.5
-endif
+
 # generate OD.c/OD.h from oresat-configs
-FW_VERSION = $(shell git describe --always)
-$(shell oresat-gen-fw-files --oresat $(ORESAT) imu -d $(ODDIR) -fw $(FW_VERSION) -hw $(BOARD))
+#
+$(shell oresat-configs canopennode od.yaml $(PROJ_SRC)/od.yaml -d $(ODDIR))
+ifneq ($(.SHELLSTATUS),0)
+  $(error oresat-configs canopennode failed to generate an Object Dictionary)
+endif
 # add them
 ALLCSRC += $(ODDIR)/OD.c
 ALLINC += $(ODDIR)
-
 
 # Enable bootloader
 ifeq ($(USE_BOOTLOADER),)
@@ -190,7 +190,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS =
+UDEFS = -DCO_VERSION_MAJOR=4 -DFW_VERSION=\"$(shell git describe --always)\"
 
 # Define ASM defines here
 UADEFS =

--- a/src/f0/app_adcs/od.yaml
+++ b/src/f0/app_adcs/od.yaml
@@ -1,0 +1,381 @@
+name: adcs
+nice_name: ADCS
+
+objects:
+  - index: 0x4000
+    name: gyroscope
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: pitch_rate
+        data_type: int16
+        description: x-axis rate
+        access_type: ro
+        unit: deg/s
+
+      - subindex: 0x2
+        name: yaw_rate
+        data_type: int16
+        description: y-axis rate
+        access_type: ro
+        unit: deg/s
+
+      - subindex: 0x3
+        name: roll_rate
+        data_type: int16
+        description: z-axis rate
+        access_type: ro
+        unit: deg/s
+
+      - subindex: 0x4
+        name: pitch_rate_raw
+        data_type: uint16
+        description: raw x-axis rate
+        access_type: ro
+
+      - subindex: 0x5
+        name: yaw_rate_raw
+        data_type: uint16
+        description: raw y-axis rate
+        access_type: ro
+
+      - subindex: 0x6
+        name: roll_rate_raw
+        data_type: uint16
+        description: raw z-axis rate
+        access_type: ro
+
+  - index: 0x4001
+    name: accelerometer
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: x acceleration
+        access_type: ro
+        unit: g
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: y acceleration
+        access_type: ro
+        unit: g
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: z acceleration
+        unit: g
+        access_type: ro
+        scale_factor: 0.001
+
+      - subindex: 0x4
+        name: x_raw
+        data_type: uint16
+        description: raw x acceleration value
+        access_type: ro
+
+      - subindex: 0x5
+        name: y_raw
+        data_type: uint16
+        description: raw y acceleration value
+        access_type: ro
+
+      - subindex: 0x6
+        name: z_raw
+        data_type: uint16
+        description: raw z acceleration value
+        access_type: ro
+
+  - index: 0x4002
+    name: temperature
+    data_type: int8
+    description: imu sensor temperature
+    access_type: ro
+    unit: C
+
+  - index: 0x4003
+    name: pos_z_magnetometer_1
+    object_type: record
+    description: +z endcard magnetometer 1 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: +z mag 1 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: +z mag 1 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: +z mag 1 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4004
+    name: pos_z_magnetometer_2
+    object_type: record
+    description: +z endcard magnetometer 2 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: +z mag 2 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: +z mag 2 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: +z mag 2 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4005
+    name: min_z_magnetometer_1
+    object_type: record
+    description: -z endcard magnetometer 1 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: -z mag 1 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: -z mag 1 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: -z mag 1 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4006
+    name: min_z_magnetometer_2
+    object_type: record
+    description: -z endcard magnetometer 2 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: -z mag 2 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: -z mag 2 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: -z mag 2 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4007
+    name: magnetorquer
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: current_x
+        data_type: int32
+        description: current feedback in the x-axis
+        access_type: ro
+        unit: uA
+
+      - subindex: 0x2
+        name: current_y
+        data_type: int32
+        description: current feedback in the y-axis
+        access_type: ro
+        unit: uA
+
+      - subindex: 0x3
+        name: current_z
+        data_type: int32
+        description: current feedback in the y-axis
+        access_type: ro
+        unit: uA
+
+      - subindex: 0x4
+        name: current_x_setpoint
+        data_type: int32
+        description: Setpoint for current in thex x-axis
+        access_type: rw
+        unit: uA
+
+      - subindex: 0x5
+        name: current_y_setpoint
+        data_type: int32
+        description: Setpoint for current in the y-axis
+        access_type: rw
+        unit: uA
+
+      - subindex: 0x6
+        name: current_z_setpoint
+        data_type: int32
+        description: Setpoint for current in thex z-axis
+        access_type: rw
+        unit: uA
+
+      - subindex: 0x7
+        name: pwm_x
+        data_type: int16
+        description: X axis
+        access_type: ro
+        low_limit: 0
+        high_limit: 10000
+        scale_factor: 0.01
+        unit: "%"
+
+      - subindex: 0x8
+        name: pwm_y
+        data_type: int16
+        description: X axis
+        access_type: ro
+        low_limit: 0
+        high_limit: 10000
+        scale_factor: 0.01
+        unit: "%"
+
+      - subindex: 0x9
+        name: pwm_z
+        data_type: int16
+        description: X axis
+        access_type: ro
+        low_limit: 0
+        high_limit: 10000
+        scale_factor: 0.01
+        unit: "%"
+
+tpdos:
+  - num: 1
+    fields:
+      - [gyroscope, pitch_rate]
+      - [gyroscope, yaw_rate]
+      - [gyroscope, roll_rate]
+    event_timer_ms: 1000
+
+  - num: 2
+    fields:
+      - [accelerometer, x]
+      - [accelerometer, y]
+      - [accelerometer, z]
+    event_timer_ms: 1000
+
+  - num: 3
+    fields:
+      - [temperature]
+    event_timer_ms: 1000
+
+  - num: 4
+    fields:
+      - [pos_z_magnetometer_1, x]
+      - [pos_z_magnetometer_1, y]
+      - [pos_z_magnetometer_1, z]
+    event_timer_ms: 1000
+
+  - num: 5
+    fields:
+      - [pos_z_magnetometer_2, x]
+      - [pos_z_magnetometer_2, y]
+      - [pos_z_magnetometer_2, z]
+    event_timer_ms: 1000
+
+  - num: 6
+    fields:
+      - [min_z_magnetometer_1, x]
+      - [min_z_magnetometer_1, y]
+      - [min_z_magnetometer_1, z]
+    event_timer_ms: 1000
+
+  - num: 7
+    fields:
+      - [min_z_magnetometer_2, x]
+      - [min_z_magnetometer_2, y]
+      - [min_z_magnetometer_2, z]
+    event_timer_ms: 1000
+
+  - num: 8
+    fields:
+      - [magnetorquer, current_x]
+      - [magnetorquer, pwm_x]
+    event_timer_ms: 1000
+
+  - num: 9
+    fields:
+      - [magnetorquer, current_y]
+      - [magnetorquer, pwm_y]
+    event_timer_ms: 1000
+
+  - num: 10
+    fields:
+      - [magnetorquer, current_z]
+      - [magnetorquer, pwm_z]
+    event_timer_ms: 1000

--- a/src/f0/app_battery/Makefile
+++ b/src/f0/app_battery/Makefile
@@ -10,7 +10,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -25,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).
@@ -111,13 +111,11 @@ ifeq ($(USE_BOOTLOADER),)
   USE_BOOTLOADER = yes
 endif
 
-ifeq ($(ORESAT),)
-  ORESAT = 0.5
-endif
-
 # generate OD.c/OD.h from oresat-configs
-FW_VERSION = $(shell git describe --always)
-$(shell oresat-gen-fw-files --oresat $(ORESAT) battery -d $(ODDIR) -fw $(FW_VERSION) -hw $(BOARD) -fw $(FW_VERSION) -hw $(BOARD))
+$(shell oresat-configs canopennode od.yaml $(PROJ_SRC)/od.yaml -d $(ODDIR))
+ifneq ($(.SHELLSTATUS),0)
+  $(error oresat-configs canopennode failed to generate an Object Dictionary)
+endif
 # add them
 ALLCSRC += $(ODDIR)/OD.c
 ALLINC += $(ODDIR)
@@ -187,7 +185,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = -DCO_VERSION_MAJOR=4 -DDEBUG_PRINT
+UDEFS = -DCO_VERSION_MAJOR=4 -DDEBUG_PRINT -DFW_VERSION=\"$(shell git describe --always)\"
 
 # Define ASM defines here
 UADEFS =

--- a/src/f0/app_battery/od.yaml
+++ b/src/f0/app_battery/od.yaml
@@ -1,0 +1,410 @@
+name: battery
+nice_name: Battery
+
+objects:
+  - index: 0x4000
+    name: pack_1
+    description: battery pack 1 telemetry
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: vbatt
+        data_type: uint16
+        description: pack voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x2
+        name: vcell_max
+        data_type: uint16
+        description: max voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x3
+        name: vcell_min
+        data_type: uint16
+        description: min voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x4
+        name: vcell
+        data_type: uint16
+        description: lowest cell voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x5
+        name: vcell_1
+        data_type: uint16
+        description: cell 1 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x6
+        name: vcell_2
+        data_type: uint16
+        description: cell 2 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x7
+        name: vcell_avg
+        data_type: uint16
+        description: average voltage of both cells
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x8
+        name: current
+        data_type: int16
+        description: pack current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x9
+        name: current_avg
+        data_type: int16
+        description: pack average current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xa
+        name: current_max
+        data_type: int16
+        description: pack max current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xb
+        name: current_min
+        data_type: int16
+        description: pack min current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xc
+        name: full_capacity
+        data_type: uint16
+        description: capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xd
+        name: reported_capacity
+        data_type: uint16
+        description: reported capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xe
+        name: time_to_empty
+        data_type: uint16
+        description: estimate of time until battery pack is empty
+        access_type: ro
+        unit: s
+
+      - subindex: 0xf
+        name: time_to_full
+        data_type: uint16
+        description: estimate of time until battery pack is full
+        access_type: ro
+        unit: s
+
+      - subindex: 0x10
+        name: cycles
+        data_type: uint16
+        description: charge/discharge cycles
+        access_type: ro
+        high_limit: 10485
+
+      - subindex: 0x11
+        name: reported_state_of_charge
+        data_type: uint8
+        description: reported charge percent
+        access_type: ro
+        high_limit: 100
+        unit: "%"
+
+      - subindex: 0x12
+        name: temperature
+        data_type: int8
+        description: temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x13
+        name: temperature_avg
+        data_type: int8
+        description: average temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x14
+        name: temperature_max
+        data_type: int8
+        description: max temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x15
+        name: temperature_min
+        data_type: int8
+        description: min temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x16
+        name: status
+        data_type: uint8
+        bit_definitions:
+          HEATER_ON: 0
+          DISCHARGE_DISABLE: 1
+          CHARGE_DISABLE: 2
+          DISCHARGE_STATUS: 3
+          CHARGE_STATUS: 4
+        access_type: ro
+
+  - index: 0x4001
+    name: pack_2
+    description: battery pack 2 telemetry
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: vbatt
+        data_type: uint16
+        description: pack voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x2
+        name: vcell_max
+        data_type: uint16
+        description: max voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x3
+        name: vcell_min
+        data_type: uint16
+        description: min voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x4
+        name: vcell
+        data_type: uint16
+        description: lowest cell voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x5
+        name: vcell_1
+        data_type: uint16
+        description: cell 1 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x6
+        name: vcell_2
+        data_type: uint16
+        description: cell 2 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x7
+        name: vcell_avg
+        data_type: uint16
+        description: average voltage of both cells
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x8
+        name: current
+        data_type: int16
+        description: pack current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x9
+        name: current_avg
+        data_type: int16
+        description: pack average current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xa
+        name: current_max
+        data_type: int16
+        description: pack max current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xb
+        name: current_min
+        data_type: int16
+        description: pack min current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xc
+        name: full_capacity
+        data_type: uint16
+        description: capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xd
+        name: reported_capacity
+        data_type: uint16
+        description: reported capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xe
+        name: time_to_empty
+        data_type: uint16
+        description: estimate of time until battery pack is empty
+        access_type: ro
+        unit: s
+
+      - subindex: 0xf
+        name: time_to_full
+        data_type: uint16
+        description: estimate of time until battery pack is full
+        access_type: ro
+        unit: s
+
+      - subindex: 0x10
+        name: cycles
+        data_type: uint16
+        description: charge/discharge cycles
+        access_type: ro
+        high_limit: 10485
+
+      - subindex: 0x11
+        name: reported_state_of_charge
+        data_type: uint8
+        description: reported charge percent
+        access_type: ro
+        high_limit: 100
+        unit: "%"
+
+      - subindex: 0x12
+        name: temperature
+        data_type: int8
+        description: temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x13
+        name: temperature_avg
+        data_type: int8
+        description: average temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x14
+        name: temperature_max
+        data_type: int8
+        description: max temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x15
+        name: temperature_min
+        data_type: int8
+        description: min temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x16
+        name: status
+        data_type: uint8
+        bit_definitions:
+          HEATER_ON: 0
+          DISCHARGE_DISABLE: 1
+          CHARGE_DISABLE: 2
+          DISCHARGE_STATUS: 3
+          CHARGE_STATUS: 4
+        access_type: ro
+
+tpdos:
+  - num: 1
+    fields:
+      - [pack_1, vbatt]
+      - [pack_1, vcell_max]
+      - [pack_1, vcell_min]
+      - [pack_1, vcell]
+    event_timer_ms: 10000
+
+  - num: 2
+    fields:
+      - [pack_1, vcell_1]
+      - [pack_1, vcell_2]
+      - [pack_1, vcell_avg]
+    event_timer_ms: 10000
+
+  - num: 3
+    fields:
+      - [pack_1, current]
+      - [pack_1, current_avg]
+      - [pack_1, current_max]
+      - [pack_1, current_min]
+    event_timer_ms: 10000
+
+  - num: 4
+    fields:
+      - [pack_1, temperature]
+      - [pack_1, temperature_avg]
+      - [pack_1, temperature_max]
+      - [pack_1, temperature_min]
+    event_timer_ms: 10000
+
+  - num: 5
+    fields:
+      - [pack_1, full_capacity]
+      - [pack_1, reported_capacity]
+      - [pack_1, reported_state_of_charge]
+      - [pack_1, status]
+    event_timer_ms: 10000
+
+  - num: 6
+    fields:
+      - [pack_2, vbatt]
+      - [pack_2, vcell_max]
+      - [pack_2, vcell_min]
+      - [pack_2, vcell]
+    event_timer_ms: 10000
+
+  - num: 7
+    fields:
+      - [pack_2, vcell_1]
+      - [pack_2, vcell_2]
+      - [pack_2, vcell_avg]
+    event_timer_ms: 10000
+
+  - num: 8
+    fields:
+      - [pack_2, current]
+      - [pack_2, current_avg]
+      - [pack_2, current_max]
+      - [pack_2, current_min]
+    event_timer_ms: 10000
+
+  - num: 9
+    fields:
+      - [pack_2, temperature]
+      - [pack_2, temperature_avg]
+      - [pack_2, temperature_max]
+      - [pack_2, temperature_min]
+    event_timer_ms: 10000
+
+  - num: 10
+    fields:
+      - [pack_2, full_capacity]
+      - [pack_2, reported_capacity]
+      - [pack_2, reported_state_of_charge]
+      - [pack_2, status]
+    event_timer_ms: 10000

--- a/src/f0/app_blinky/Makefile
+++ b/src/f0/app_blinky/Makefile
@@ -10,7 +10,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -25,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).

--- a/src/f0/app_bootloader/Makefile
+++ b/src/f0/app_bootloader/Makefile
@@ -10,7 +10,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -25,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).

--- a/src/f0/app_devboard/Makefile
+++ b/src/f0/app_devboard/Makefile
@@ -10,7 +10,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -25,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).
@@ -111,13 +111,11 @@ ifeq ($(USE_BOOTLOADER),)
   USE_BOOTLOADER = yes
 endif
 
-ifeq ($(ORESAT),)
-  ORESAT = 0.5
-endif
-
 # generate OD.c/OD.h from oresat-configs
-FW_VERSION = $(shell git describe --always)
-$(shell oresat-gen-fw-files --oresat $(ORESAT) base -d $(ODDIR) -fw $(FW_VERSION) -hw $(BOARD))
+$(shell oresat-configs canopennode $(PROJ_SRC)/od.yaml -d $(ODDIR))
+ifneq ($(.SHELLSTATUS),0)
+  $(error oresat-configs canopennode failed to generate an Object Dictionary)
+endif
 # add them
 ALLCSRC += $(ODDIR)/OD.c
 ALLINC += $(ODDIR)
@@ -186,7 +184,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = 
+UDEFS = -DCO_VERSION_MAJOR=4 -DFW_VERSION=\"$(shell git describe --always)\"
 
 # Define ASM defines here
 UADEFS =

--- a/src/f0/app_devboard/cfg/CO_driver_custom.h
+++ b/src/f0/app_devboard/cfg/CO_driver_custom.h
@@ -5,17 +5,6 @@
 extern "C" {
 #endif
 
-// See CANopenNode/CANopen.c lines 181 - 192. I'm 80% sure that it's a bug in
-// the library that it doesn't handle the case where OD_CNT_{T,R}PDO is defined
-// but zero; as written it only compiles when they're either undefined or
-// greater than zero. None of the firmware projects use RPDOs so they've been
-// disabled in CO_CONFIG_PDO (common/include/CO_driver_target.h) but this is
-// one of the few project that also doesn't do TPDOs. Our generated object
-// dictionaries (od/OD.h) always define OD_CNT_{T,R}PDO. The two defines below
-// are what CANopen does when OD_CNT_TPDO is undefined and should probably do
-// also when they are defined but zero.
-#define OD_ENTRY_H1800 NULL
-#define OD_ENTRY_H1A00 NULL
 
 #ifdef __cplusplus
 }

--- a/src/f0/app_protocard/Makefile
+++ b/src/f0/app_protocard/Makefile
@@ -10,7 +10,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -25,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).
@@ -111,13 +111,11 @@ ifeq ($(USE_BOOTLOADER),)
   USE_BOOTLOADER = yes
 endif
 
-ifeq ($(ORESAT),)
-  ORESAT = 0.5
-endif
-
 # generate OD.c/OD.h from oresat-configs
-FW_VERSION = $(shell git describe --always)
-$(shell oresat-gen-fw-files --oresat $(ORESAT) base -d $(ODDIR) -fw $(FW_VERSION) -hw $(BOARD))
+$(shell oresat-configs canopennode $(PROJ_SRC)/od.yaml -d $(ODDIR))
+ifneq ($(.SHELLSTATUS),0)
+  $(error oresat-configs canopennode failed to generate an Object Dictionary)
+endif
 # add them
 ALLCSRC += $(ODDIR)/OD.c
 ALLINC += $(ODDIR)
@@ -186,7 +184,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = 
+UDEFS = -DCO_VERSION_MAJOR=4 -DFW_VERSION=\"$(shell git describe --always)\"
 
 # Define ASM defines here
 UADEFS =

--- a/src/f0/app_protocard/cfg/CO_driver_custom.h
+++ b/src/f0/app_protocard/cfg/CO_driver_custom.h
@@ -5,17 +5,7 @@
 extern "C" {
 #endif
 
-// See CANopenNode/CANopen.c lines 181 - 192. I'm 80% sure that it's a bug in
-// the library that it doesn't handle the case where OD_CNT_{T,R}PDO is defined
-// but zero; as written it only compiles when they're either undefined or
-// greater than zero. None of the firmware projects use RPDOs so they've been
-// disabled in CO_CONFIG_PDO (common/include/CO_driver_target.h) but this is
-// one of the few project that also doesn't do TPDOs. Our generated object
-// dictionaries (od/OD.h) always define OD_CNT_{T,R}PDO. The two defines below
-// are what CANopen does when OD_CNT_TPDO is undefined and should probably do
-// also when they are defined but zero.
-#define OD_ENTRY_H1800 NULL
-#define OD_ENTRY_H1A00 NULL
+
 
 #ifdef __cplusplus
 }

--- a/src/f0/app_solar/Makefile
+++ b/src/f0/app_solar/Makefile
@@ -10,7 +10,7 @@ endif
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = 
+  USE_COPT =
 endif
 
 # C++ specific options here (added to USE_OPT).
@@ -25,7 +25,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT =
 endif
 
 # Enable this if you want link time optimizations (LTO).
@@ -111,13 +111,11 @@ ifeq ($(USE_BOOTLOADER),)
   USE_BOOTLOADER = yes
 endif
 
-ifeq ($(ORESAT),)
-  ORESAT = 0.5
-endif
-
 # generate OD.c/OD.h from oresat-configs
-FW_VERSION = $(shell git describe --always)
-$(shell oresat-gen-fw-files --oresat $(ORESAT) solar -d $(ODDIR) -fw $(FW_VERSION) -hw $(BOARD))
+$(shell oresat-configs canopennode od.yaml $(PROJ_SRC)/od.yaml -d $(ODDIR))
+ifneq ($(.SHELLSTATUS),0)
+  $(error oresat-configs canopennode failed to generate an Object Dictionary)
+endif
 # add them
 ALLCSRC += $(ODDIR)/OD.c
 ALLINC += $(ODDIR)
@@ -184,7 +182,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = -D_XOPEN_SOURCE=0 -D_FORTIFY_SOURCE=0 -D__ARM_FP=0 -DDEBUG_PRINT
+UDEFS = -D_XOPEN_SOURCE=0 -D_FORTIFY_SOURCE=0 -D__ARM_FP=0 -DDEBUG_PRINT -DFW_VERSION=\"$(shell git describe --always)\"
 
 # Define ASM defines here
 UADEFS =

--- a/src/f0/app_solar/od.yaml
+++ b/src/f0/app_solar/od.yaml
@@ -1,0 +1,176 @@
+name: solar
+nice_name: Solar
+
+objects:
+  - index: 0x4000
+    name: output
+    description: solar module output
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: voltage
+        data_type: uint16
+        description: voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x2
+        name: current
+        data_type: int16
+        description: current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x3
+        name: power
+        data_type: uint16
+        description: power
+        access_type: ro
+        unit: mW
+
+      - subindex: 0x4
+        name: voltage_avg
+        data_type: uint16
+        description: average voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x5
+        name: current_avg
+        data_type: int16
+        description: average current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x6
+        name: power_avg
+        data_type: uint16
+        description: average power
+        access_type: ro
+        unit: mW
+
+      - subindex: 0x7
+        name: voltage_max
+        data_type: uint16
+        description: max voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x8
+        name: current_max
+        data_type: int16
+        description: max current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x9
+        name: power_max
+        data_type: uint16
+        description: max power
+        access_type: ro
+        unit: mW
+
+      - subindex: 0xa
+        name: energy
+        data_type: uint16
+        description: storing energy
+        access_type: ro
+        unit: mJ
+
+  - index: 0x4001
+    name: cell_1
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: temperature
+        data_type: int8
+        description: cell 1 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x2
+        name: temperature_min
+        data_type: int8
+        description: min cell 1 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x3
+        name: temperature_max
+        data_type: int8
+        description: max cell 1 temperature
+        access_type: ro
+        unit: C
+
+  - index: 0x4002
+    name: cell_2
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: temperature
+        data_type: int8
+        description: cell 2 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x2
+        name: temperature_min
+        data_type: int8
+        description: min cell 2 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x3
+        name: temperature_max
+        data_type: int8
+        description: max cell 2 temperature
+        access_type: ro
+        unit: C
+
+  - index: 0x4003
+    name: mppt_alg
+    data_type: uint8
+    description: mppt (maximum power point tracking) algorithm
+    value_descriptions:
+      perturb_and_observe: 0
+    access_type: rw
+
+  - index: 0x4004
+    name: lt1618_iadj
+    data_type: uint16
+    description: i_adj pin voltage
+    access_type: ro
+    unit: mV
+
+tpdos:
+  - num: 1
+    fields:
+      - [output, voltage]
+      - [output, current]
+      - [output, power]
+      - [output, voltage_avg]
+    event_timer_ms: 10000
+
+  - num: 2
+    fields:
+      - [output, current_avg]
+      - [output, power_avg]
+      - [output, voltage_max]
+      - [output, current_max]
+    event_timer_ms: 10000
+
+  - num: 3
+    fields:
+      - [output, power_max]
+      - [output, energy]
+    event_timer_ms: 10000
+
+  - num: 4
+    fields:
+      - [cell_1, temperature]
+      - [cell_2, temperature]
+      - [cell_1, temperature_min]
+      - [cell_2, temperature_min]
+      - [cell_1, temperature_max]
+      - [cell_2, temperature_max]
+    event_timer_ms: 10000


### PR DESCRIPTION
Moved the `od.yaml` configs for each card and the common firmware `od.yaml` that used to live `oresat-configs`.

Hardware and firmware versions are now passed in as build defines and used in a OD extension. These used to be set via runtime arguments to `oresat-configs`, but `oresat-configs` no longer knows any thing about the data in ODs.

Reworked the PDO COB-ID fix to work with `oresat-configs` v1.

`oresat-config` v1 will also fix #113 