### PR TITLE
Switch to native CANopenNode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,3 @@
-if(CONFIG_CANOPENNODE_V4)
-
-zephyr_syscall_include_directories(lib)   
-
-endif()
-
 zephyr_include_directories(.)
 zephyr_include_directories(lib)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
 zephyr_include_directories(.)
 
-add_subdirectory(canopennode_v4)
+#add_subdirectory(canopennode_v4)
 add_subdirectory(util)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,3 @@
 zephyr_include_directories(.)
 
-#add_subdirectory(canopennode_v4)
 add_subdirectory(util)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -1,2 +1,2 @@
-rsource "canopennode_v4/Kconfig"
+#rsource "canopennode_v4/Kconfig"
 rsource "util/Kconfig"

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -1,2 +1,1 @@
-#rsource "canopennode_v4/Kconfig"
 rsource "util/Kconfig"

--- a/lib/util/board_sensors.c
+++ b/lib/util/board_sensors.c
@@ -2,7 +2,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 #include <canopennode.h>
-#include <OD.h>
+#include <CO_OD.h>
 
 #if defined(BOARD_NUCLEO_F091RC)
 #define DIE_TEMP_ALIAS(i) DT_ALIAS(_CONCAT(die_temp, i))
@@ -35,10 +35,12 @@ void board_sensors_fill_od(void)
 	sensor_sample_fetch(devs_die_temp[0]);
 	sensor_channel_get(devs_die_temp[0], SENSOR_CHAN_DIE_TEMP, &die_temp);
 
-	CO_LOCK_OD(CO->CANmodule);
-	OD_RAM.x3003_system.vrefint = (uint16_t)sensor_value_to_milli(&vref),
-	OD_RAM.x3003_system.temperature = die_temp.val1;
-	CO_UNLOCK_OD(CO->CANmodule);
+#if 0 /* Not currently defined in object dictionary. */
+	CO_LOCK_OD();
+	CO_OD_RAM.x3003_system.vrefint = (uint16_t)sensor_value_to_milli(&vref),
+	CO_OD_RAM.x3003_system.temperature = die_temp.val1;
+	CO_UNLOCK_OD();
+#endif
 }
 
 #else
@@ -49,16 +51,18 @@ void board_sensors_init(void)
 
 void board_sensors_fill_od(void)
 {
+#if 0 /* Not currently defined in object dictionary. */
 	static uint16_t vrevint = 4578;
 	static int8_t temp = 20;
 
-	CO_LOCK_OD(CO->CANmodule);
-	OD_RAM.x3003_system.vrefint = vrevint--;
-	OD_RAM.x3003_system.temperature = temp++;
+	CO_LOCK_OD();
+	CO_OD_RAM.x3003_system.vrefint = vrevint--;
+	CO_OD_RAM.x3003_system.temperature = temp++;
 	if (temp > 60) {
 		temp = -60;
 	}
-	CO_UNLOCK_OD(CO->CANmodule);
+	CO_UNLOCK_OD();
+#endif
 }
 
 #endif

--- a/lib/util/oresat.h
+++ b/lib/util/oresat.h
@@ -2,7 +2,7 @@
 #define ORESAT_H
 
 #include <CANopen.h>
-#include <OD.h>
+#include <CO_OD.h>
 #ifdef STM32F091xC
 #include "stm32f0xx_hal.h"
 #endif
@@ -24,9 +24,10 @@ static inline uint8_t oresat_get_node_id(void)
 
 static inline void oresat_fix_pdo_cob_ids(uint8_t node_id)
 {
+#if 0
 	int i;
 	uint32_t cob_id;
-	OD_entry_t *entry;
+	CO_OD_entry_t *entry;
 	for (int e = 0; e < OD->size; e++) {
 		entry = &OD->list[e];
 #if OD_CNT_RPDO > 0
@@ -48,6 +49,7 @@ static inline void oresat_fix_pdo_cob_ids(uint8_t node_id)
 		}
 #endif
 	}
+#endif
 }
 
 #endif

--- a/scripts/pyocd.yaml
+++ b/scripts/pyocd.yaml
@@ -1,0 +1,3 @@
+pack:
+  - /home/peters/src/oresat/firmware/common/scripts/NXP.MCXN947_DFP.19.0.0.pack
+

--- a/west.yml
+++ b/west.yml
@@ -10,6 +10,7 @@ manifest:
       url-base: https://github.com/CANopenNode
   defaults:
     remote: oresat
+  group-filter: [+optional]
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
@@ -21,10 +22,8 @@ manifest:
           - cmsis_6
           - hal_stm32
           - hal_nxp
-    - name: CANopenNode
-      remote: canopennode
-      revision: 58012aa
-      path: common/lib/canopennode_v4/CANopenNode
+          - canopennode
+          - mcuboot
     - name: oresat-mag-app
       revision: main
       path: apps/mag


### PR DESCRIPTION
Disable CANopenNode_v4.

Add NXP.MCXN947_DFP.19.0.0.pack reference to
scripts/pyocd.yaml. User will need to download
the pack and place in the same folder.

Disable vrefint and temperature CAN sensors for now.