### PR TITLE
Fix Broken Probe-rs Debug Support

### DIFF
--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -34,7 +34,7 @@ patches:
     email: hidden@github.com
     merge-pr: https://github.com/zephyrproject-rtos/zephyr/pull/106778
     merge-status: true
-    module: scripts/west_commands/runners
+    module: zephyr/scripts/west_commands/runners
     path: scripts-runners-rename-run-client-and-fix-GDB-SIGINT-handling.patch
     sha256sum: 099a9612a01805ad22fed73f1d601f962da109b7a6a9114c5f3c4f51571b9917
     upstreamable: true


### PR DESCRIPTION
The module path in zephyr/patches.yml was incorrect. Fixing it makes the patch work correctly.